### PR TITLE
Fix site "usage" page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,9 @@ under the License.
     <javaVersion>7</javaVersion>
     <mavenVersion>3.2.5</mavenVersion>
     <project.build.outputTimestamp>2022-07-17T16:33:17Z</project.build.outputTimestamp>
+
+    <!-- Used by site documentation as well, do not remove -->
+    <mavenFilteringVersion>3.2.0</mavenFilteringVersion>
   </properties>
 
   <dependencies>
@@ -131,7 +134,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-filtering</artifactId>
-      <version>3.2.0</version>
+      <version>${mavenFilteringVersion}</version>
     </dependency>
 
     <!-- plexus -->


### PR DESCRIPTION
The property was removed as there was only one usage of
it in POM, and I was unaware it is also used in documentation.