### PR TITLE
Get rid of build warnings and obvious typo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,6 @@ under the License.
             </goals>
             <configuration>
               <version>1.1.0</version>
-              <useJava5>true</useJava5>
               <models>
                 <model>src/main/mdo/remote-resources.mdo</model>
               </models>
@@ -304,7 +303,6 @@ under the License.
             </goals>
             <configuration>
               <version>1.0.0</version>
-              <useJava5>true</useJava5>
               <models>
                 <model>src/main/mdo/supplemental-model.mdo</model>
               </models>

--- a/src/main/java/org/apache/maven/plugin/resources/remote/ProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/ProcessRemoteResourcesMojo.java
@@ -672,8 +672,8 @@ public class ProcessRemoteResourcesMojo
             }
             catch ( ProjectBuildingException e )
             {
-                getLog().warn( "Invalid project model for artifact [" + artifact.getArtifactId() + ":"
-                                   + artifact.getGroupId() + ":" + artifact.getVersion() + "]. "
+                getLog().warn( "Invalid project model for artifact [" + artifact.getGroupId() + ":"
+                                   + artifact.getArtifactId() + ":" + artifact.getVersion() + "]. "
                                    + "It will be ignored by the remote resources Mojo." );
                 continue;
             }


### PR DESCRIPTION
The build spits a lot of warnings due use of obsolete modello config,

Also, the log was mixed up: was AGV not GAV.