### PR TITLE
[MRRESOURCES-126] Get rid of legacy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,18 @@ under the License.
     <project.build.outputTimestamp>2022-07-17T16:33:17Z</project.build.outputTimestamp>
 
     <!-- Used by site documentation as well, do not remove -->
-    <mavenFilteringVersion>3.2.0</mavenFilteringVersion>
+    <mavenFilteringVersion>3.3.0</mavenFilteringVersion>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.5.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <!-- maven core -->
@@ -119,47 +129,36 @@ under the License.
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-archiver</artifactId>
-      <version>3.5.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-artifact-transfer</artifactId>
-      <version>0.13.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-common-artifact-filters</artifactId>
-      <version>3.2.0</version>
+      <version>3.6.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-filtering</artifactId>
       <version>${mavenFilteringVersion}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-common-artifact-filters</artifactId>
+      <version>3.3.2</version>
+    </dependency>
 
     <!-- plexus -->
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-resources</artifactId>
-      <version>1.1.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-container-default</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>1.2.0</version>
     </dependency>
 
     <!-- other -->
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.6</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
-      <version>1.7</version>
+      <artifactId>velocity-engine-core</artifactId>
+      <version>2.3</version>
     </dependency>
 
     <!-- test -->

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-verifier</artifactId>
-      <version>1.8.0</version>
+      <version>2.0.0-M1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/it/resources/bootstrap/resource-bundle-with-type-and-classifier/pom.xml
+++ b/src/it/resources/bootstrap/resource-bundle-with-type-and-classifier/pom.xml
@@ -30,7 +30,7 @@
   </parent>
   
   <artifactId>resource-bundle-with-type-and-classifier</artifactId>
-  <packaging>pom</packaging>
+  <packaging>jar</packaging>
 
   <name>Resource Bundle with a Type and Classifier</name>
   
@@ -52,9 +52,25 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <classifier>test</classifier>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-test-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>test</classifier>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/it/resources/bootstrap/resource-bundle-with-type-and-classifier/pom.xml
+++ b/src/it/resources/bootstrap/resource-bundle-with-type-and-classifier/pom.xml
@@ -30,7 +30,7 @@
   </parent>
   
   <artifactId>resource-bundle-with-type-and-classifier</artifactId>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
 
   <name>Resource Bundle with a Type and Classifier</name>
   

--- a/src/it/resources/generate-from-bundle-with-type-and-classifier/pom.xml
+++ b/src/it/resources/generate-from-bundle-with-type-and-classifier/pom.xml
@@ -29,6 +29,7 @@ under the License.
   </parent>
   
   <artifactId>generate-from-bundle-with-type-and-classifier</artifactId>
+  <packaging>pom</packaging>
   
   <build>
     <plugins>

--- a/src/it/resources/run-only-at-execution-root/pom.xml
+++ b/src/it/resources/run-only-at-execution-root/pom.xml
@@ -46,10 +46,10 @@ under the License.
           <execution>
             <id>remote-resources</id>
             <goals>
-              <goal>process</goal>
+              <goal>aggregator-process</goal>
             </goals>
             <configuration>
-              <runOnlyAtExecutionRoot>true</runOnlyAtExecutionRoot>
+<!--              <runOnlyAtExecutionRoot>true</runOnlyAtExecutionRoot>-->
               <resourceBundles>
                 <resourceBundle>org.apache.maven.plugin.rresource.it:resource-bundle-with-template:${project.version}</resourceBundle>
               </resourceBundles>

--- a/src/it/resources/run-only-at-execution-root/pom.xml
+++ b/src/it/resources/run-only-at-execution-root/pom.xml
@@ -45,11 +45,11 @@ under the License.
         <executions>
           <execution>
             <id>remote-resources</id>
+            <inherited>false</inherited>
             <goals>
-              <goal>aggregator-process</goal>
+              <goal>aggregate</goal>
             </goals>
             <configuration>
-<!--              <runOnlyAtExecutionRoot>true</runOnlyAtExecutionRoot>-->
               <resourceBundles>
                 <resourceBundle>org.apache.maven.plugin.rresource.it:resource-bundle-with-template:${project.version}</resourceBundle>
               </resourceBundles>

--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -1,0 +1,1358 @@
+package org.apache.maven.plugin.resources.remote;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.Writer;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.text.SimpleDateFormat;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.apache.commons.io.output.DeferredFileOutputStream;
+import org.apache.maven.RepositoryUtils;
+import org.apache.maven.archiver.MavenArchiver;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Organization;
+import org.apache.maven.model.Resource;
+import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.resources.remote.io.xpp3.RemoteResourcesBundleXpp3Reader;
+import org.apache.maven.plugin.resources.remote.io.xpp3.SupplementalDataModelXpp3Reader;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingResult;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactFilterException;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactIdFilter;
+import org.apache.maven.shared.artifact.filter.collection.FilterArtifacts;
+import org.apache.maven.shared.artifact.filter.collection.GroupIdFilter;
+import org.apache.maven.shared.artifact.filter.collection.ProjectTransitivityFilter;
+import org.apache.maven.shared.artifact.filter.collection.ScopeFilter;
+import org.apache.maven.shared.filtering.MavenFileFilter;
+import org.apache.maven.shared.filtering.MavenFileFilterRequest;
+import org.apache.maven.shared.filtering.MavenFilteringException;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.Velocity;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.exception.MethodInvocationException;
+import org.apache.velocity.exception.ParseErrorException;
+import org.apache.velocity.exception.ResourceNotFoundException;
+import org.apache.velocity.exception.VelocityException;
+import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
+import org.codehaus.plexus.resource.ResourceManager;
+import org.codehaus.plexus.resource.loader.FileResourceLoader;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.IOUtil;
+import org.codehaus.plexus.util.ReaderFactory;
+import org.codehaus.plexus.util.StringUtils;
+import org.codehaus.plexus.util.WriterFactory;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.artifact.ArtifactType;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.util.artifact.JavaScopes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>
+ * Pull down resourceBundles containing remote resources and process the resources contained inside. When that is done,
+ * the resources are injected into the current (in-memory) Maven project, making them available to the process-resources
+ * phase.
+ * </p>
+ * <p>
+ * Resources that end in ".vm" are treated as Velocity templates. For those, the ".vm" is stripped off for the final
+ * artifact name and it's fed through Velocity to have properties expanded, conditions processed, etc...
+ * </p>
+ * Resources that don't end in ".vm" are copied "as is".
+ */
+public abstract class AbstractProcessRemoteResourcesMojo
+    extends AbstractMojo
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private static final String TEMPLATE_SUFFIX = ".vm";
+
+    /**
+     * <p>
+     * In cases where a local resource overrides one from a remote resource bundle, that resource should be filtered if
+     * the resource set specifies it. In those cases, this parameter defines the list of delimiters for filterable
+     * expressions. These delimiters are specified in the form 'beginToken*endToken'. If no '*' is given, the delimiter
+     * is assumed to be the same for start and end.
+     * </p>
+     * <p>
+     * So, the default filtering delimiters might be specified as:
+     * </p>
+     * 
+     * <pre>
+     * &lt;delimiters&gt;
+     *   &lt;delimiter&gt;${*}&lt;/delimiter&gt;
+     *   &lt;delimiter&gt;@&lt;/delimiter&gt;
+     * &lt;/delimiters&gt;
+     * </pre>
+     * Since the '@' delimiter is the same on both ends, we don't need to specify '@*@' (though we can).
+     *
+     * @since 1.1
+     */
+    @Parameter
+    protected List<String> filterDelimiters;
+
+    /**
+     * @since 1.1
+     */
+    @Parameter( defaultValue = "true" )
+    protected boolean useDefaultFilterDelimiters;
+
+    /**
+     * The character encoding scheme to be applied when filtering resources.
+     */
+    @Parameter( property = "encoding", defaultValue = "${project.build.sourceEncoding}" )
+    protected String encoding;
+
+    /**
+     * The directory where processed resources will be placed for packaging.
+     */
+    @Parameter( defaultValue = "${project.build.directory}/maven-shared-archive-resources" )
+    private File outputDirectory;
+
+    /**
+     * The directory containing extra information appended to the generated resources.
+     */
+    @Parameter( defaultValue = "${basedir}/src/main/appended-resources" )
+    private File appendedResourcesDirectory;
+
+    /**
+     * Supplemental model data. Useful when processing
+     * artifacts with incomplete POM metadata.
+     * <p/>
+     * By default, this Mojo looks for supplemental model data in the file
+     * "<code>${appendedResourcesDirectory}/supplemental-models.xml</code>".
+     *
+     * @since 1.0-alpha-5
+     */
+    @Parameter
+    private String[] supplementalModels;
+
+    /**
+     * List of artifacts that are added to the search path when looking
+     * for supplementalModels, expressed with <code>groupId:artifactId:version[:type[:classifier]]</code> format.
+     *
+     * @since 1.1
+     */
+    @Parameter
+    private List<String> supplementalModelArtifacts;
+
+    /**
+     * The resource bundles that will be retrieved and processed,
+     * expressed with <code>groupId:artifactId:version[:type[:classifier]]</code> format.
+     */
+    @Parameter( required = true )
+    private List<String> resourceBundles;
+
+    /**
+     * Skip remote-resource processing
+     *
+     * @since 1.0-alpha-5
+     */
+    @Parameter( property = "remoteresources.skip", defaultValue = "false" )
+    private boolean skip;
+
+    /**
+     * Attaches the resources to the main build of the project as a resource directory.
+     *
+     * @since 1.5
+     */
+    @Parameter( defaultValue = "true", property = "attachToMain" )
+    private boolean attachToMain;
+
+    /**
+     * Attaches the resources to the test build of the project as a resource directory.
+     *
+     * @since 1.5
+     */
+    @Parameter( defaultValue = "true", property = "attachToTest" )
+    private boolean attachToTest;
+
+    /**
+     * Additional properties to be passed to Velocity.
+     * <p/>
+     * Several properties are automatically added:<ul>
+     * <li><code>project</code> - the current MavenProject </li>
+     * <li><code>projects</code> - the list of dependency projects</li>
+     * <li><code>projectsSortedByOrganization</code> - the list of dependency projects sorted by organization</li>
+     * <li><code>projectTimespan</code> - the timespan of the current project (requires inceptionYear in pom)</li>
+     * <li><code>locator</code> - the ResourceManager that can be used to retrieve additional resources</li>
+     * </ul>
+     * See <a
+     * href="https://maven.apache.org/ref/current/maven-project/apidocs/org/apache/maven/project/MavenProject.html"> the
+     * javadoc for MavenProject</a> for information about the properties on the MavenProject.
+     */
+    @Parameter
+    protected Map<String, Object> properties = new HashMap<>();
+
+    /**
+     * Whether to include properties defined in the project when filtering resources.
+     *
+     * @since 1.2
+     */
+    @Parameter( defaultValue = "false" )
+    protected boolean includeProjectProperties = false;
+
+    /**
+     * When the result of velocity transformation fits in memory, it is compared with the actual contents on disk
+     * to eliminate unnecessary destination file overwrite. This improves build times since further build steps
+     * typically rely on the modification date.
+     *
+     * @since 1.6
+     */
+    @Parameter( defaultValue = "5242880" )
+    protected int velocityFilterInMemoryThreshold = 5 * 1024 * 1024;
+
+    /**
+     * The Maven session.
+     */
+    @Parameter( defaultValue = "${session}", readonly = true, required = true )
+    protected MavenSession mavenSession;
+
+    /**
+     * Scope to include. An Empty string indicates all scopes (default is "runtime").
+     *
+     * @since 1.0
+     */
+    @Parameter( property = "includeScope", defaultValue = "runtime" )
+    protected String includeScope;
+
+    /**
+     * Scope to exclude. An Empty string indicates no scopes (default).
+     *
+     * @since 1.0
+     */
+    @Parameter( property = "excludeScope", defaultValue = "" )
+    protected String excludeScope;
+
+    /**
+     * When resolving project dependencies, specify the scopes to include.
+     * The default is the same as "includeScope" if there are no exclude scopes set.
+     * Otherwise, it defaults to "test" to grab all the dependencies so the
+     * exclude filters can filter out what is not needed.
+     *
+     * @since 1.5
+     */
+    @Parameter
+    protected String[] resolveScopes;
+
+    /**
+     * Comma separated list of Artifact names to exclude.
+     *
+     * @since 1.0
+     */
+    @Parameter( property = "excludeArtifactIds", defaultValue = "" )
+    protected String excludeArtifactIds;
+
+    /**
+     * Comma separated list of Artifact names to include.
+     *
+     * @since 1.0
+     */
+    @Parameter( property = "includeArtifactIds", defaultValue = "" )
+    protected String includeArtifactIds;
+
+    /**
+     * Comma separated list of GroupId Names to exclude.
+     *
+     * @since 1.0
+     */
+    @Parameter( property = "excludeGroupIds", defaultValue = "" )
+    protected String excludeGroupIds;
+
+    /**
+     * Comma separated list of GroupIds to include.
+     *
+     * @since 1.0
+     */
+    @Parameter( property = "includeGroupIds", defaultValue = "" )
+    protected String includeGroupIds;
+
+    /**
+     * If we should exclude transitive dependencies
+     *
+     * @since 1.0
+     */
+    @Parameter( property = "excludeTransitive", defaultValue = "false" )
+    protected boolean excludeTransitive;
+
+    /**
+     * Timestamp for reproducible output archive entries, either formatted as ISO 8601
+     * <code>yyyy-MM-dd'T'HH:mm:ssXXX</code> or as an int representing seconds since the epoch (like
+     * <a href="https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>).
+     */
+    @Parameter( defaultValue = "${project.build.outputTimestamp}" )
+    private String outputTimestamp;
+
+    @Component
+    protected RepositorySystem repositorySystem;
+
+    /**
+     * Filtering support, for local resources that override those in the remote bundle.
+     */
+    @Component
+    private MavenFileFilter fileFilter;
+
+    @Component
+    private ResourceManager locator;
+
+    @Component
+    private ProjectBuilder projectBuilder;
+
+    @Component
+    private ArtifactHandlerManager artifactHandlerManager;
+
+    /**
+     * Map of artifacts to supplemental project object models.
+     */
+    private Map<String, Model> supplementModels;
+
+    /**
+     * Merges supplemental data model with artifact metadata. Useful when processing artifacts with
+     * incomplete POM metadata.
+     */
+    private final ModelInheritanceAssembler inheritanceAssembler = new ModelInheritanceAssembler();
+
+    private VelocityEngine velocity;
+
+    @Override
+    public void execute()
+        throws MojoExecutionException
+    {
+        if ( skip )
+        {
+            logger.info( "Skipping remote resources execution." );
+            return;
+        }
+
+        if ( StringUtils.isEmpty( encoding ) )
+        {
+            logger.warn( "File encoding has not been set, using platform encoding " + ReaderFactory.FILE_ENCODING
+                               + ", i.e. build is platform dependent!" );
+        }
+
+        if ( resolveScopes == null )
+        {
+            resolveScopes =
+                new String[] { StringUtils.isEmpty( this.includeScope ) ? JavaScopes.TEST : this.includeScope };
+        }
+
+        if ( supplementalModels == null )
+        {
+            File sups = new File( appendedResourcesDirectory, "supplemental-models.xml" );
+            if ( sups.exists() )
+            {
+                try
+                {
+                    supplementalModels = new String[] { sups.toURI().toURL().toString() };
+                }
+                catch ( MalformedURLException e )
+                {
+                    // ignore
+                    logger.debug( "URL issue with supplemental-models.xml: " + e );
+                }
+            }
+        }
+
+        configureLocator();
+
+        if ( includeProjectProperties )
+        {
+            final Properties projectProperties = mavenSession.getCurrentProject().getProperties();
+            for ( Object key : projectProperties.keySet() )
+            {
+                properties.put( key.toString(), projectProperties.get( key ).toString() );
+            }
+        }
+
+        ClassLoader origLoader = Thread.currentThread().getContextClassLoader();
+        try
+        {
+            validate();
+
+            List<File> resourceBundleArtifacts = downloadBundles( resourceBundles );
+            supplementModels = loadSupplements( supplementalModels );
+
+            ClassLoader classLoader = initalizeClassloader( resourceBundleArtifacts );
+
+            Thread.currentThread().setContextClassLoader( classLoader );
+
+            velocity = new VelocityEngine();
+            velocity.setProperty( "resource.loaders", "classpath" );
+            velocity.setProperty( "resource.loader.classpath.class", ClasspathResourceLoader.class.getName() );
+            velocity.init();
+
+            VelocityContext context = buildVelocityContext( properties );
+
+            processResourceBundles( classLoader, context );
+
+            if ( outputDirectory.exists() )
+            {
+                // ----------------------------------------------------------------------------
+                // Push our newly generated resources directory into the MavenProject so that
+                // these resources can be picked up by the process-resources phase.
+                // ----------------------------------------------------------------------------
+                Resource resource = new Resource();
+                resource.setDirectory( outputDirectory.getAbsolutePath() );
+                // MRRESOURCES-61 handle main and test resources separately
+                if ( attachToMain )
+                {
+                    mavenSession.getCurrentProject().getResources().add( resource );
+                }
+                if ( attachToTest )
+                {
+                    mavenSession.getCurrentProject().getTestResources().add( resource );
+                }
+
+                // ----------------------------------------------------------------------------
+                // Write out archiver dot file
+                // ----------------------------------------------------------------------------
+                try
+                {
+                    File dotFile = new File( mavenSession.getCurrentProject().getBuild().getDirectory(), ".plxarc" );
+                    FileUtils.mkdir( dotFile.getParentFile().getAbsolutePath() );
+                    FileUtils.fileWrite( dotFile.getAbsolutePath(), outputDirectory.getName() );
+                }
+                catch ( IOException e )
+                {
+                    throw new MojoExecutionException( "Error creating dot file for archiving instructions.", e );
+                }
+            }
+        }
+        finally
+        {
+            Thread.currentThread().setContextClassLoader( origLoader );
+        }
+    }
+
+    private void configureLocator()
+        throws MojoExecutionException
+    {
+        if ( supplementalModelArtifacts != null && !supplementalModelArtifacts.isEmpty() )
+        {
+            List<File> artifacts = downloadBundles( supplementalModelArtifacts );
+
+            for ( File artifact : artifacts )
+            {
+                if ( artifact.isDirectory() )
+                {
+                    locator.addSearchPath( FileResourceLoader.ID, artifact.getAbsolutePath() );
+                }
+                else
+                {
+                    try
+                    {
+                        locator.addSearchPath( "jar", "jar:" + artifact.toURI().toURL().toExternalForm() );
+                    }
+                    catch ( MalformedURLException e )
+                    {
+                        throw new MojoExecutionException( "Could not use jar " + artifact.getAbsolutePath(), e );
+                    }
+                }
+            }
+
+        }
+
+        locator.addSearchPath( FileResourceLoader.ID, mavenSession.getCurrentProject()
+                .getFile().getParentFile().getAbsolutePath() );
+        if ( appendedResourcesDirectory != null )
+        {
+            locator.addSearchPath( FileResourceLoader.ID, appendedResourcesDirectory.getAbsolutePath() );
+        }
+        locator.addSearchPath( "url", "" );
+        locator.setOutputDirectory( new File( mavenSession.getCurrentProject().getBuild().getDirectory() ) );
+    }
+
+    protected List<MavenProject> getProjects()
+    {
+        List<MavenProject> projects = new ArrayList<>();
+
+        // add filters in well known order, least specific to most specific
+        FilterArtifacts filter = new FilterArtifacts();
+
+        Set<org.apache.maven.artifact.Artifact> artifacts = new LinkedHashSet<>();
+        artifacts.addAll( getProjectArtifacts() );
+        artifacts.addAll( getAllDependencies() );
+        if ( this.excludeTransitive )
+        {
+            filter.addFilter( new ProjectTransitivityFilter( getDirectDependencies(), true ) );
+        }
+
+        filter.addFilter( new ScopeFilter( this.includeScope, this.excludeScope ) );
+        filter.addFilter( new GroupIdFilter( this.includeGroupIds, this.excludeGroupIds ) );
+        filter.addFilter( new ArtifactIdFilter( this.includeArtifactIds, this.excludeArtifactIds ) );
+
+        // perform filtering
+        try
+        {
+            artifacts = filter.filter( artifacts );
+        }
+        catch ( ArtifactFilterException e )
+        {
+            throw new IllegalStateException( e.getMessage(), e );
+        }
+
+        logger.debug( "PROJECTS: {}", artifacts );
+
+        for ( org.apache.maven.artifact.Artifact artifact : artifacts )
+        {
+            if ( artifact.isSnapshot() )
+            {
+                artifact.setVersion( artifact.getBaseVersion() );
+            }
+
+            logger.debug( "Building project for {}", artifact );
+            MavenProject p;
+            try
+            {
+                ProjectBuildingRequest req = new DefaultProjectBuildingRequest()
+                        .setValidationLevel( ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL )
+                        .setProcessPlugins( false )
+                        .setRepositorySession( mavenSession.getRepositorySession() )
+                        .setSystemProperties( mavenSession.getSystemProperties() )
+                        .setUserProperties( mavenSession.getUserProperties() )
+                        .setLocalRepository( mavenSession.getLocalRepository() )
+                        .setRemoteRepositories( mavenSession.getCurrentProject().getRemoteArtifactRepositories() );
+                ProjectBuildingResult res = projectBuilder.build( artifact, req );
+                p = res.getProject();
+            }
+            catch ( ProjectBuildingException e )
+            {
+                logger.warn( "Invalid project model for artifact [" + artifact.getGroupId() + ":"
+                                   + artifact.getArtifactId() + ":" + artifact.getVersion() + "]. "
+                                   + "It will be ignored by the remote resources Mojo." );
+                continue;
+            }
+
+            String supplementKey =
+                generateSupplementMapKey( p.getModel().getGroupId(), p.getModel().getArtifactId() );
+
+            if ( supplementModels.containsKey( supplementKey ) )
+            {
+                Model mergedModel = mergeModels( p.getModel(), supplementModels.get( supplementKey ) );
+                MavenProject mergedProject = new MavenProject( mergedModel );
+                projects.add( mergedProject );
+                mergedProject.setArtifact( artifact );
+                mergedProject.setVersion( artifact.getVersion() );
+                logger.debug( "Adding project with groupId [{}] (supplemented)", mergedProject.getGroupId() );
+            }
+            else
+            {
+                projects.add( p );
+                logger.debug( "Adding project with groupId [{}]", p.getGroupId() );
+            }
+        }
+        projects.sort( new ProjectComparator() );
+        return projects;
+    }
+
+    /**
+     * Returns involved {@link MavenProject}s as {@link org.apache.maven.artifact.Artifact}.
+     */
+    protected abstract Set<org.apache.maven.artifact.Artifact> getProjectArtifacts();
+
+    /**
+     * Returns all the transitive hull of all the involved maven projects.
+     */
+    protected abstract Set<org.apache.maven.artifact.Artifact> getAllDependencies();
+
+    /**
+     * Returns all the direct dependencies of all the involved maven projects.
+     */
+    protected abstract Set<org.apache.maven.artifact.Artifact> getDirectDependencies();
+
+    protected Map<Organization, List<MavenProject>> getProjectsSortedByOrganization( List<MavenProject> projects )
+    {
+        Map<Organization, List<MavenProject>> organizations =
+            new TreeMap<>( new OrganizationComparator() );
+        List<MavenProject> unknownOrganization = new ArrayList<>();
+
+        for ( MavenProject p : projects )
+        {
+            if ( p.getOrganization() != null && StringUtils.isNotEmpty( p.getOrganization().getName() ) )
+            {
+                List<MavenProject> sortedProjects = organizations.get( p.getOrganization() );
+                if ( sortedProjects == null )
+                {
+                    sortedProjects = new ArrayList<>();
+                }
+                sortedProjects.add( p );
+
+                organizations.put( p.getOrganization(), sortedProjects );
+            }
+            else
+            {
+                unknownOrganization.add( p );
+            }
+        }
+        if ( !unknownOrganization.isEmpty() )
+        {
+            Organization unknownOrg = new Organization();
+            unknownOrg.setName( "an unknown organization" );
+            organizations.put( unknownOrg, unknownOrganization );
+        }
+
+        return organizations;
+    }
+
+    protected boolean copyResourceIfExists( File file, String relFileName, VelocityContext context )
+        throws IOException, MojoExecutionException
+    {
+        for ( Resource resource : mavenSession.getCurrentProject().getResources() )
+        {
+            File resourceDirectory = new File( resource.getDirectory() );
+
+            if ( !resourceDirectory.exists() )
+            {
+                continue;
+            }
+
+            // TODO - really should use the resource includes/excludes and name mapping
+            File source = new File( resourceDirectory, relFileName );
+            File templateSource = new File( resourceDirectory, relFileName + TEMPLATE_SUFFIX );
+
+            if ( !source.exists() && templateSource.exists() )
+            {
+                source = templateSource;
+            }
+
+            if ( source.exists() && !source.equals( file ) )
+            {
+                if ( source == templateSource )
+                {
+                    try ( DeferredFileOutputStream os = 
+                                    new DeferredFileOutputStream( velocityFilterInMemoryThreshold, file ) )
+                    {
+                        try ( Reader reader = getReader( source ); Writer writer = getWriter( os ) )
+                        {
+                            velocity.evaluate( context, writer, "", reader );
+                        }
+                        catch ( ParseErrorException | MethodInvocationException | ResourceNotFoundException e )
+                        {
+                            throw new MojoExecutionException( "Error rendering velocity resource: " + source, e );
+                        }
+                        fileWriteIfDiffers( os );
+                    }
+                }
+                else if ( resource.isFiltering() )
+                {
+
+                    MavenFileFilterRequest req = setupRequest( resource, source, file );
+
+                    try
+                    {
+                        fileFilter.copyFile( req );
+                    }
+                    catch ( MavenFilteringException e )
+                    {
+                        throw new MojoExecutionException( "Error filtering resource: " + source, e );
+                    }
+                }
+                else
+                {
+                    FileUtils.copyFile( source, file );
+                }
+
+                // exclude the original (so eclipse doesn't complain about duplicate resources)
+                resource.addExclude( relFileName );
+
+                return true;
+            }
+
+        }
+        return false;
+    }
+
+    private Reader getReader( File source ) throws IOException
+    {
+        if ( encoding != null )
+        {
+            return new InputStreamReader( Files.newInputStream( source.toPath() ), encoding );
+        }
+        else
+        {
+            return ReaderFactory.newPlatformReader( source );
+        }
+    }
+    
+    private Writer getWriter( OutputStream os ) throws IOException
+    {
+        if ( encoding != null )
+        {
+            return new OutputStreamWriter( os, encoding );
+        }
+        else
+        {
+            return WriterFactory.newPlatformWriter( os );
+        }
+    }
+
+    /**
+     * If the transformation result fits in memory and the destination file already exists
+     * then both are compared.
+     * <p>If destination file is byte-by-byte equal, then it is not overwritten.
+     * This improves subsequent compilation times since upstream plugins property see that
+     * the resource was not modified.
+     * <p>Note: the method should be called after {@link DeferredFileOutputStream#close}
+     *
+     * @param outStream Deferred stream
+     * @throws IOException On IO error.
+     */
+    private void fileWriteIfDiffers( DeferredFileOutputStream outStream )
+        throws IOException
+    {
+        File file = outStream.getFile();
+        if ( outStream.isThresholdExceeded() )
+        {
+            logger.info( "File {}} was overwritten due to content limit threshold {} reached",
+                    file, outStream.getThreshold() );
+            return;
+        }
+        boolean needOverwrite = true;
+
+        if ( file.exists() )
+        {
+            try ( InputStream is = Files.newInputStream( file.toPath() );
+                 InputStream newContents = new ByteArrayInputStream( outStream.getData() ) )
+            {
+                needOverwrite = !IOUtil.contentEquals( is, newContents );
+                if ( logger.isDebugEnabled() )
+                {
+                    logger.debug( "File {} contents {}", file, ( needOverwrite ? "differs" : "does not differ" ) );
+                }
+            }
+        }
+
+        if ( !needOverwrite )
+        {
+            logger.debug( "File {} is up to date", file );
+            return;
+        }
+        logger.debug( "Writing {}", file );
+        
+        try ( OutputStream os = Files.newOutputStream( file.toPath() ) )
+        {
+            outStream.writeTo( os );
+        }
+    }
+
+    private MavenFileFilterRequest setupRequest( Resource resource, File source, File file )
+    {
+        MavenFileFilterRequest req = new MavenFileFilterRequest();
+        req.setFrom( source );
+        req.setTo( file );
+        req.setFiltering( resource.isFiltering() );
+
+        req.setMavenProject( mavenSession.getCurrentProject() );
+        req.setMavenSession( mavenSession );
+        req.setInjectProjectBuildFilters( true );
+
+        if ( encoding != null )
+        {
+            req.setEncoding( encoding );
+        }
+
+        if ( filterDelimiters != null && !filterDelimiters.isEmpty() )
+        {
+            LinkedHashSet<String> delims = new LinkedHashSet<>();
+            if ( useDefaultFilterDelimiters )
+            {
+                delims.addAll( req.getDelimiters() );
+            }
+
+            for ( String delim : filterDelimiters )
+            {
+                if ( delim == null )
+                {
+                    delims.add( "${*}" );
+                }
+                else
+                {
+                    delims.add( delim );
+                }
+            }
+
+            req.setDelimiters( delims );
+        }
+
+        return req;
+    }
+
+    protected void validate()
+        throws MojoExecutionException
+    {
+        int bundleCount = 1;
+
+        for ( String artifactDescriptor : resourceBundles )
+        {
+            // groupId:artifactId:version, groupId:artifactId:version:type
+            // or groupId:artifactId:version:type:classifier
+            String[] s = StringUtils.split( artifactDescriptor, ":" );
+
+            if ( s.length < 3 || s.length > 5 )
+            {
+                String position;
+
+                if ( bundleCount == 1 )
+                {
+                    position = "1st";
+                }
+                else if ( bundleCount == 2 )
+                {
+                    position = "2nd";
+                }
+                else if ( bundleCount == 3 )
+                {
+                    position = "3rd";
+                }
+                else
+                {
+                    position = bundleCount + "th";
+                }
+
+                throw new MojoExecutionException( "The " + position
+                    + " resource bundle configured must specify a groupId, artifactId, "
+                    + " version and, optionally, type and classifier for a remote resource bundle. "
+                    + "Must be of the form <resourceBundle>groupId:artifactId:version</resourceBundle>, "
+                    + "<resourceBundle>groupId:artifactId:version:type</resourceBundle> or "
+                    + "<resourceBundle>groupId:artifactId:version:type:classifier</resourceBundle>" );
+            }
+
+            bundleCount++;
+        }
+
+    }
+
+    private static final String KEY_PROJECTS = "projects";
+    private static final String KEY_PROJECTS_ORGS = "projectsSortedByOrganization";
+
+    protected VelocityContext buildVelocityContext( Map<String, Object> properties )
+    {
+        // the following properties are expensive to calculate, so we provide them lazily
+        VelocityContext context = new VelocityContext( properties )
+        {
+            @Override
+            public Object internalGet( String key )
+            {
+                Object result = super.internalGet( key );
+                if ( result == null && key != null && key.startsWith( KEY_PROJECTS ) && containsKey( key ) )
+                {
+                    // calculate and put projects* properties
+                    List<MavenProject> projects = getProjects();
+                    put( KEY_PROJECTS, projects );
+                    put( KEY_PROJECTS_ORGS, getProjectsSortedByOrganization( projects ) );
+                    return super.internalGet( key );
+                }
+                return result;
+            }
+        };
+        // to have a consistent getKeys()/containsKey() behaviour, keys must be present from the start
+        context.put( KEY_PROJECTS, null );
+        context.put( KEY_PROJECTS_ORGS, null );
+        // the following properties are cheap to calculate, so we provide them eagerly
+
+        // Reproducible Builds: try to use reproducible output timestamp 
+        MavenArchiver archiver = new MavenArchiver();
+        Date outputDate = archiver.parseOutputTimestamp( outputTimestamp );
+
+        String inceptionYear = mavenSession.getCurrentProject().getInceptionYear();
+        String year = new SimpleDateFormat( "yyyy" ).format( ( outputDate == null ) ? new Date() : outputDate );
+
+        if ( StringUtils.isEmpty( inceptionYear ) )
+        {
+            if ( logger.isDebugEnabled() )
+            {
+                logger.debug( "inceptionYear not specified, defaulting to {}", year );
+            }
+
+            inceptionYear = year;
+        }
+        context.put( "project", mavenSession.getCurrentProject() );
+        context.put( "presentYear", year );
+        context.put( "locator", locator );
+
+        if ( inceptionYear.equals( year ) )
+        {
+            context.put( "projectTimespan", year );
+        }
+        else
+        {
+            context.put( "projectTimespan", inceptionYear + "-" + year );
+        }
+        return context;
+    }
+
+    private List<File> downloadBundles( List<String> bundles )
+        throws MojoExecutionException
+    {
+        List<File> bundleArtifacts = new ArrayList<>();
+
+        for ( String artifactDescriptor : bundles )
+        {
+            logger.info( "Preparing remote bundle {}", artifactDescriptor );
+            // groupId:artifactId:version[:type[:classifier]]
+            String[] s = artifactDescriptor.split( ":" );
+
+            File artifactFile = null;
+            // check if the artifact is part of the reactor
+            if ( mavenSession != null )
+            {
+                List<MavenProject> list = mavenSession.getProjects();
+                for ( MavenProject p : list )
+                {
+                    if ( s[0].equals( p.getGroupId() ) && s[1].equals( p.getArtifactId() )
+                        && s[2].equals( p.getVersion() ) )
+                    {
+                        if ( s.length >= 4 && "test-jar".equals( s[3] ) )
+                        {
+                            artifactFile = new File( p.getBuild().getTestOutputDirectory() );
+                        }
+                        else
+                        {
+                            artifactFile = new File( p.getBuild().getOutputDirectory() );
+                        }
+                    }
+                }
+            }
+            if ( artifactFile == null || !artifactFile.exists() )
+            {
+                String g = s[0];
+                String a = s[1];
+                String v = s[2];
+                String type = ( s.length >= 4 ? s[3] : "jar" );
+                ArtifactType artifactType = RepositoryUtils.newArtifactType( type,
+                        artifactHandlerManager.getArtifactHandler( type ) );
+                String classifier = ( s.length == 5 ? s[4] : artifactType.getClassifier() );
+
+                DefaultArtifact artifact = new DefaultArtifact(
+                        g, a, classifier, artifactType.getExtension(), v, artifactType );
+
+                try
+                {
+                    ArtifactRequest request = new ArtifactRequest(
+                            artifact,
+                            RepositoryUtils.toRepos( mavenSession.getCurrentProject().getRemoteArtifactRepositories() ),
+                            "remote-resources" );
+                    ArtifactResult result = repositorySystem.resolveArtifact(
+                            mavenSession.getRepositorySession(), request );
+                    artifactFile = result.getArtifact().getFile();
+                }
+                catch ( ArtifactResolutionException e )
+                {
+                    throw new MojoExecutionException( "Error processing remote resources", e );
+                }
+
+            }
+            bundleArtifacts.add( artifactFile );
+        }
+
+        return bundleArtifacts;
+    }
+
+    private ClassLoader initalizeClassloader( List<File> artifacts )
+        throws MojoExecutionException
+    {
+        RemoteResourcesClassLoader cl = new RemoteResourcesClassLoader( null );
+        try
+        {
+            for ( File artifact : artifacts )
+            {
+                cl.addURL( artifact.toURI().toURL() );
+            }
+            return cl;
+        }
+        catch ( MalformedURLException e )
+        {
+            throw new MojoExecutionException( "Unable to configure resources classloader: " + e.getMessage(), e );
+        }
+    }
+
+    protected void processResourceBundles( ClassLoader classLoader, VelocityContext context )
+        throws MojoExecutionException
+    {
+        List<Map.Entry<String, RemoteResourcesBundle>> remoteResources =
+            new ArrayList<>();
+        int bundleCount = 0;
+        int resourceCount = 0;
+
+        // list remote resources form bundles
+        try
+        {
+            RemoteResourcesBundleXpp3Reader bundleReader = new RemoteResourcesBundleXpp3Reader();
+
+            for ( Enumeration<URL> e =
+                classLoader.getResources( BundleRemoteResourcesMojo.RESOURCES_MANIFEST ); e.hasMoreElements(); )
+            {
+                URL url = e.nextElement();
+                bundleCount++;
+                logger.debug( "processResourceBundle on bundle#{} {}", bundleCount, url );
+
+                RemoteResourcesBundle bundle;
+                
+                try ( InputStream in = url.openStream() )
+                {
+                    bundle = bundleReader.read( in );
+                }
+
+                int n = 0;
+                for ( String bundleResource : bundle.getRemoteResources() )
+                {
+                    n++;
+                    resourceCount++;
+                    logger.debug( "bundle#{} resource#{} {}", bundleCount, n, bundleResource );
+                    remoteResources.add( new AbstractMap.SimpleEntry<>( bundleResource, bundle ) );
+                }
+            }
+        }
+        catch ( IOException ioe )
+        {
+            throw new MojoExecutionException( "Error finding remote resources manifests", ioe );
+        }
+        catch ( XmlPullParserException xppe )
+        {
+            throw new MojoExecutionException( "Error parsing remote resource bundle descriptor.", xppe );
+        }
+
+        logger.info( "Copying {} resource{} from {} bundle{}.",
+                resourceCount, ( resourceCount > 1 ) ? "s" : "", bundleCount, ( bundleCount > 1 ) ? "s" : "" );
+
+        String velocityResource = null;
+        try
+        {
+
+            for ( Map.Entry<String, RemoteResourcesBundle> entry : remoteResources )
+            {
+                String bundleResource = entry.getKey();
+                RemoteResourcesBundle bundle = entry.getValue();
+
+                String projectResource = bundleResource;
+
+                boolean doVelocity = false;
+                if ( projectResource.endsWith( TEMPLATE_SUFFIX ) )
+                {
+                    projectResource = projectResource.substring( 0, projectResource.length() - 3 );
+                    velocityResource = bundleResource;
+                    doVelocity = true;
+                }
+
+                // Don't overwrite resource that are already being provided.
+
+                File f = new File( outputDirectory, projectResource );
+
+                FileUtils.mkdir( f.getParentFile().getAbsolutePath() );
+
+                if ( !copyResourceIfExists( f, projectResource, context ) )
+                {
+                    if ( doVelocity )
+                    {
+                        try ( DeferredFileOutputStream os =
+                                        new DeferredFileOutputStream( velocityFilterInMemoryThreshold, f ) )
+                        {
+                            try ( Writer writer = bundle.getSourceEncoding() == null ? new OutputStreamWriter( os )
+                                            : new OutputStreamWriter( os, bundle.getSourceEncoding() ) )
+                            {
+                                if ( bundle.getSourceEncoding() == null )
+                                {
+                                    // TODO: Is this correct? Shouldn't we behave like the rest of maven and fail
+                                    // down to JVM default instead ISO-8859-1 ?
+                                    velocity.mergeTemplate( bundleResource, "ISO-8859-1", context, writer );
+                                }
+                                else
+                                {
+                                    velocity.mergeTemplate( bundleResource, bundle.getSourceEncoding(), context,
+                                                            writer );
+                                }
+                            }
+                            fileWriteIfDiffers( os );
+                        }
+                    }
+                    else
+                    {
+                        URL resUrl = classLoader.getResource( bundleResource );
+                        if ( resUrl != null )
+                        {
+                            FileUtils.copyURLToFile( resUrl, f );
+                        }
+                    }
+
+                    File appendedResourceFile = new File( appendedResourcesDirectory, projectResource );
+                    File appendedVmResourceFile = new File( appendedResourcesDirectory, projectResource + ".vm" );
+
+                    if ( appendedResourceFile.exists() )
+                    {
+                        logger.info( "Copying appended resource: {}", projectResource );
+                        try ( InputStream in = Files.newInputStream( appendedResourceFile.toPath() );
+                              OutputStream out = new FileOutputStream( f, true ) )
+                        {
+                            IOUtil.copy( in, out );
+                        }
+                        
+                    }
+                    else if ( appendedVmResourceFile.exists() )
+                    {
+                        logger.info( "Filtering appended resource: {}.vm", projectResource );
+                        
+
+                        try ( Reader reader = new FileReader( appendedVmResourceFile ); 
+                              Writer writer = getWriter( bundle, f ) )
+                        {
+                            Velocity.init();
+                            Velocity.evaluate( context, writer, "remote-resources", reader );
+                        }
+                    }
+                }
+            }
+        }
+        catch ( IOException ioe )
+        {
+            throw new MojoExecutionException( "Error reading remote resource", ioe );
+        }
+        catch ( VelocityException e )
+        {
+            throw new MojoExecutionException( "Error rendering Velocity resource '" + velocityResource + "'", e );
+        }
+    }
+
+    private Writer getWriter( RemoteResourcesBundle bundle, File f )
+        throws IOException
+    {
+        Writer writer;
+        if ( bundle.getSourceEncoding() == null )
+        {
+            writer = new PrintWriter( new FileWriter( f, true ) );
+        }
+        else
+        {
+            writer = new PrintWriter( new OutputStreamWriter( new FileOutputStream( f, true ),
+                                                              bundle.getSourceEncoding() ) );
+        }
+        return writer;
+    }
+
+    protected Model getSupplement( Xpp3Dom supplementModelXml )
+        throws MojoExecutionException
+    {
+        MavenXpp3Reader modelReader = new MavenXpp3Reader();
+        Model model = null;
+
+        try
+        {
+            model = modelReader.read( new StringReader( supplementModelXml.toString() ) );
+            String groupId = model.getGroupId();
+            String artifactId = model.getArtifactId();
+
+            if ( groupId == null || groupId.trim().equals( "" ) )
+            {
+                throw new MojoExecutionException( "Supplemental project XML "
+                    + "requires that a <groupId> element be present." );
+            }
+
+            if ( artifactId == null || artifactId.trim().equals( "" ) )
+            {
+                throw new MojoExecutionException( "Supplemental project XML "
+                    + "requires that a <artifactId> element be present." );
+            }
+        }
+        catch ( IOException e )
+        {
+            logger.warn( "Unable to read supplemental XML: {}", e.getMessage(), e );
+        }
+        catch ( XmlPullParserException e )
+        {
+            logger.warn( "Unable to parse supplemental XML: {}", e.getMessage(), e );
+        }
+
+        return model;
+    }
+
+    protected Model mergeModels( Model parent, Model child )
+    {
+        inheritanceAssembler.assembleModelInheritance( child, parent );
+        return child;
+    }
+
+    private static String generateSupplementMapKey( String groupId, String artifactId )
+    {
+        return groupId.trim() + ":" + artifactId.trim();
+    }
+
+    private Map<String, Model> loadSupplements( String[] models )
+        throws MojoExecutionException
+    {
+        if ( models == null )
+        {
+            logger.debug( "Supplemental data models won't be loaded. No models specified." );
+            return Collections.emptyMap();
+        }
+
+        List<Supplement> supplements = new ArrayList<>();
+        for ( String set : models )
+        {
+            logger.debug( "Preparing ruleset: {}", set );
+            try
+            {
+                File f = locator.getResourceAsFile( set, getLocationTemp( set ) );
+
+                if ( null == f || !f.exists() )
+                {
+                    throw new MojoExecutionException( "Cold not resolve " + set );
+                }
+                if ( !f.canRead() )
+                {
+                    throw new MojoExecutionException( "Supplemental data models won't be loaded. " + "File "
+                        + f.getAbsolutePath() + " cannot be read, check permissions on the file." );
+                }
+
+                logger.debug( "Loading supplemental models from {}", f.getAbsolutePath() );
+
+                SupplementalDataModelXpp3Reader reader = new SupplementalDataModelXpp3Reader();
+                SupplementalDataModel supplementalModel = reader.read( new FileReader( f ) );
+                supplements.addAll( supplementalModel.getSupplement() );
+            }
+            catch ( Exception e )
+            {
+                String msg = "Error loading supplemental data models: " + e.getMessage();
+                logger.error( msg, e );
+                throw new MojoExecutionException( msg, e );
+            }
+        }
+
+        logger.debug( "Loading supplements complete." );
+
+        Map<String, Model> supplementMap = new HashMap<>();
+        for ( Supplement sd : supplements )
+        {
+            Xpp3Dom dom = (Xpp3Dom) sd.getProject();
+
+            Model m = getSupplement( dom );
+            supplementMap.put( generateSupplementMapKey( m.getGroupId(), m.getArtifactId() ), m );
+        }
+
+        return supplementMap;
+    }
+
+    /**
+     * Convenience method to get the location of the specified file name.
+     *
+     * @param name the name of the file whose location is to be resolved
+     * @return a String that contains the absolute file name of the file
+     */
+    private String getLocationTemp( String name )
+    {
+        String loc = name;
+        if ( loc.indexOf( '/' ) != -1 )
+        {
+            loc = loc.substring( loc.lastIndexOf( '/' ) + 1 );
+        }
+        if ( loc.indexOf( '\\' ) != -1 )
+        {
+            loc = loc.substring( loc.lastIndexOf( '\\' ) + 1 );
+        }
+        logger.debug( "Before: {} After: {}", name, loc );
+        return loc;
+    }
+
+    static class OrganizationComparator
+        implements Comparator<Organization>
+    {
+        @Override
+        public int compare( Organization org1, Organization org2 )
+        {
+            int i = compareStrings( org1.getName(), org2.getName() );
+            if ( i == 0 )
+            {
+                i = compareStrings( org1.getUrl(), org2.getUrl() );
+            }
+            return i;
+        }
+
+        private int compareStrings( String s1, String s2 )
+        {
+            if ( s1 == null && s2 == null )
+            {
+                return 0;
+            }
+            else if ( s1 == null )
+            {
+                return 1;
+            }
+            else if ( s2 == null )
+            {
+                return -1;
+            }
+
+            return s1.compareToIgnoreCase( s2 );
+        }
+    }
+
+    static class ProjectComparator
+        implements Comparator<MavenProject>
+    {
+        @Override
+        public int compare( MavenProject p1, MavenProject p2 )
+        {
+            return p1.getArtifact().compareTo( p2.getArtifact() );
+        }
+    }
+
+}

--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -121,6 +121,9 @@ import org.slf4j.LoggerFactory;
  * artifact name and it's fed through Velocity to have properties expanded, conditions processed, etc...
  * </p>
  * Resources that don't end in ".vm" are copied "as is".
+ * <p>
+ * This is a support abstract class, with two non-aggregating and aggregating implementations.
+ * </p>
  */
 public abstract class AbstractProcessRemoteResourcesMojo
     extends AbstractMojo
@@ -231,7 +234,6 @@ public abstract class AbstractProcessRemoteResourcesMojo
 
     /**
      * Additional properties to be passed to Velocity.
-     * <p/>
      * Several properties are automatically added:<ul>
      * <li><code>project</code> - the current MavenProject </li>
      * <li><code>projects</code> - the list of dependency projects</li>

--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -535,7 +535,6 @@ public abstract class AbstractProcessRemoteResourcesMojo
         FilterArtifacts filter = new FilterArtifacts();
 
         Set<Artifact> artifacts = new LinkedHashSet<>();
-        artifacts.addAll( getProjectArtifacts() );
         artifacts.addAll( getAllDependencies() );
         if ( this.excludeTransitive )
         {
@@ -609,11 +608,6 @@ public abstract class AbstractProcessRemoteResourcesMojo
         projects.sort( new ProjectComparator() );
         return projects;
     }
-
-    /**
-     * Returns involved {@link MavenProject}s as {@link Artifact}.
-     */
-    protected abstract Set<Artifact> getProjectArtifacts();
 
     /**
      * Returns all the transitive hull of all the involved maven projects.

--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -107,8 +107,6 @@ import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.util.artifact.JavaScopes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * <p>
@@ -126,10 +124,8 @@ import org.slf4j.LoggerFactory;
  * </p>
  */
 public abstract class AbstractProcessRemoteResourcesMojo
-    extends AbstractMojo
+        extends AbstractMojo
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
-
     private static final String TEMPLATE_SUFFIX = ".vm";
 
     /**
@@ -142,7 +138,7 @@ public abstract class AbstractProcessRemoteResourcesMojo
      * <p>
      * So, the default filtering delimiters might be specified as:
      * </p>
-     * 
+     *
      * <pre>
      * &lt;delimiters&gt;
      *   &lt;delimiter&gt;${*}&lt;/delimiter&gt;
@@ -386,24 +382,24 @@ public abstract class AbstractProcessRemoteResourcesMojo
 
     @Override
     public void execute()
-        throws MojoExecutionException
+            throws MojoExecutionException
     {
         if ( skip )
         {
-            logger.info( "Skipping remote resources execution." );
+            getLog().info( "Skipping remote resources execution." );
             return;
         }
 
         if ( StringUtils.isEmpty( encoding ) )
         {
-            logger.warn( "File encoding has not been set, using platform encoding " + ReaderFactory.FILE_ENCODING
-                               + ", i.e. build is platform dependent!" );
+            getLog().warn( "File encoding has not been set, using platform encoding " + ReaderFactory.FILE_ENCODING
+                    + ", i.e. build is platform dependent!" );
         }
 
         if ( resolveScopes == null )
         {
             resolveScopes =
-                new String[] { StringUtils.isEmpty( this.includeScope ) ? JavaScopes.TEST : this.includeScope };
+                    new String[] {StringUtils.isEmpty( this.includeScope ) ? JavaScopes.TEST : this.includeScope};
         }
 
         if ( supplementalModels == null )
@@ -413,12 +409,12 @@ public abstract class AbstractProcessRemoteResourcesMojo
             {
                 try
                 {
-                    supplementalModels = new String[] { sups.toURI().toURL().toString() };
+                    supplementalModels = new String[] {sups.toURI().toURL().toString()};
                 }
                 catch ( MalformedURLException e )
                 {
                     // ignore
-                    logger.debug( "URL issue with supplemental-models.xml: " + e );
+                    getLog().debug( "URL issue with supplemental-models.xml: " + e );
                 }
             }
         }
@@ -495,7 +491,7 @@ public abstract class AbstractProcessRemoteResourcesMojo
     }
 
     private void configureLocator()
-        throws MojoExecutionException
+            throws MojoExecutionException
     {
         if ( supplementalModelArtifacts != null && !supplementalModelArtifacts.isEmpty() )
         {
@@ -560,7 +556,7 @@ public abstract class AbstractProcessRemoteResourcesMojo
             throw new IllegalStateException( e.getMessage(), e );
         }
 
-        logger.debug( "PROJECTS: {}", artifacts );
+        getLog().debug( "PROJECTS: " + artifacts );
 
         for ( Artifact artifact : artifacts )
         {
@@ -569,7 +565,7 @@ public abstract class AbstractProcessRemoteResourcesMojo
                 artifact.setVersion( artifact.getBaseVersion() );
             }
 
-            logger.debug( "Building project for {}", artifact );
+            getLog().debug( "Building project for " + artifact );
             MavenProject p;
             try
             {
@@ -586,14 +582,14 @@ public abstract class AbstractProcessRemoteResourcesMojo
             }
             catch ( ProjectBuildingException e )
             {
-                logger.warn( "Invalid project model for artifact [" + artifact.getGroupId() + ":"
-                                   + artifact.getArtifactId() + ":" + artifact.getVersion() + "]. "
-                                   + "It will be ignored by the remote resources Mojo." );
+                getLog().warn( "Invalid project model for artifact [" + artifact.getGroupId() + ":"
+                        + artifact.getArtifactId() + ":" + artifact.getVersion() + "]. "
+                        + "It will be ignored by the remote resources Mojo." );
                 continue;
             }
 
             String supplementKey =
-                generateSupplementMapKey( p.getModel().getGroupId(), p.getModel().getArtifactId() );
+                    generateSupplementMapKey( p.getModel().getGroupId(), p.getModel().getArtifactId() );
 
             if ( supplementModels.containsKey( supplementKey ) )
             {
@@ -602,12 +598,12 @@ public abstract class AbstractProcessRemoteResourcesMojo
                 projects.add( mergedProject );
                 mergedProject.setArtifact( artifact );
                 mergedProject.setVersion( artifact.getVersion() );
-                logger.debug( "Adding project with groupId [{}] (supplemented)", mergedProject.getGroupId() );
+                getLog().debug( "Adding project with groupId [" + mergedProject.getGroupId() + "] (supplemented)" );
             }
             else
             {
                 projects.add( p );
-                logger.debug( "Adding project with groupId [{}]", p.getGroupId() );
+                getLog().debug( "Adding project with groupId [" + p.getGroupId() + "]" );
             }
         }
         projects.sort( new ProjectComparator() );
@@ -632,7 +628,7 @@ public abstract class AbstractProcessRemoteResourcesMojo
     protected Map<Organization, List<MavenProject>> getProjectsSortedByOrganization( List<MavenProject> projects )
     {
         Map<Organization, List<MavenProject>> organizations =
-            new TreeMap<>( new OrganizationComparator() );
+                new TreeMap<>( new OrganizationComparator() );
         List<MavenProject> unknownOrganization = new ArrayList<>();
 
         for ( MavenProject p : projects )
@@ -664,7 +660,7 @@ public abstract class AbstractProcessRemoteResourcesMojo
     }
 
     protected boolean copyResourceIfExists( File file, String relFileName, VelocityContext context )
-        throws IOException, MojoExecutionException
+            throws IOException, MojoExecutionException
     {
         for ( Resource resource : project.getResources() )
         {
@@ -688,8 +684,8 @@ public abstract class AbstractProcessRemoteResourcesMojo
             {
                 if ( source == templateSource )
                 {
-                    try ( DeferredFileOutputStream os = 
-                                    new DeferredFileOutputStream( velocityFilterInMemoryThreshold, file ) )
+                    try ( DeferredFileOutputStream os =
+                                  new DeferredFileOutputStream( velocityFilterInMemoryThreshold, file ) )
                     {
                         try ( Reader reader = getReader( source ); Writer writer = getWriter( os ) )
                         {
@@ -742,7 +738,7 @@ public abstract class AbstractProcessRemoteResourcesMojo
             return ReaderFactory.newPlatformReader( source );
         }
     }
-    
+
     private Writer getWriter( OutputStream os ) throws IOException
     {
         if ( encoding != null )
@@ -767,13 +763,14 @@ public abstract class AbstractProcessRemoteResourcesMojo
      * @throws IOException On IO error.
      */
     private void fileWriteIfDiffers( DeferredFileOutputStream outStream )
-        throws IOException
+            throws IOException
     {
         File file = outStream.getFile();
         if ( outStream.isThresholdExceeded() )
         {
-            logger.info( "File {}} was overwritten due to content limit threshold {} reached",
-                    file, outStream.getThreshold() );
+            getLog().info(
+                    "File " + file + " was overwritten due to content limit threshold " + outStream.getThreshold()
+                            + " reached" );
             return;
         }
         boolean needOverwrite = true;
@@ -781,23 +778,23 @@ public abstract class AbstractProcessRemoteResourcesMojo
         if ( file.exists() )
         {
             try ( InputStream is = Files.newInputStream( file.toPath() );
-                 InputStream newContents = new ByteArrayInputStream( outStream.getData() ) )
+                  InputStream newContents = new ByteArrayInputStream( outStream.getData() ) )
             {
                 needOverwrite = !IOUtil.contentEquals( is, newContents );
-                if ( logger.isDebugEnabled() )
+                if ( getLog().isDebugEnabled() )
                 {
-                    logger.debug( "File {} contents {}", file, ( needOverwrite ? "differs" : "does not differ" ) );
+                    getLog().debug( "File " + file + " contents " + ( needOverwrite ? "differs" : "does not differ" ) );
                 }
             }
         }
 
         if ( !needOverwrite )
         {
-            logger.debug( "File {} is up to date", file );
+            getLog().debug( "File " + file + " is up to date" );
             return;
         }
-        logger.debug( "Writing {}", file );
-        
+        getLog().debug( "Writing " + file );
+
         try ( OutputStream os = Files.newOutputStream( file.toPath() ) )
         {
             outStream.writeTo( os );
@@ -847,7 +844,7 @@ public abstract class AbstractProcessRemoteResourcesMojo
     }
 
     protected void validate()
-        throws MojoExecutionException
+            throws MojoExecutionException
     {
         int bundleCount = 1;
 
@@ -879,11 +876,11 @@ public abstract class AbstractProcessRemoteResourcesMojo
                 }
 
                 throw new MojoExecutionException( "The " + position
-                    + " resource bundle configured must specify a groupId, artifactId, "
-                    + " version and, optionally, type and classifier for a remote resource bundle. "
-                    + "Must be of the form <resourceBundle>groupId:artifactId:version</resourceBundle>, "
-                    + "<resourceBundle>groupId:artifactId:version:type</resourceBundle> or "
-                    + "<resourceBundle>groupId:artifactId:version:type:classifier</resourceBundle>" );
+                        + " resource bundle configured must specify a groupId, artifactId, "
+                        + " version and, optionally, type and classifier for a remote resource bundle. "
+                        + "Must be of the form <resourceBundle>groupId:artifactId:version</resourceBundle>, "
+                        + "<resourceBundle>groupId:artifactId:version:type</resourceBundle> or "
+                        + "<resourceBundle>groupId:artifactId:version:type:classifier</resourceBundle>" );
             }
 
             bundleCount++;
@@ -928,9 +925,9 @@ public abstract class AbstractProcessRemoteResourcesMojo
 
         if ( StringUtils.isEmpty( inceptionYear ) )
         {
-            if ( logger.isDebugEnabled() )
+            if ( getLog().isDebugEnabled() )
             {
-                logger.debug( "inceptionYear not specified, defaulting to {}", year );
+                getLog().debug( "inceptionYear not specified, defaulting to " + year );
             }
 
             inceptionYear = year;
@@ -951,13 +948,13 @@ public abstract class AbstractProcessRemoteResourcesMojo
     }
 
     private List<File> downloadBundles( List<String> bundles )
-        throws MojoExecutionException
+            throws MojoExecutionException
     {
         List<File> bundleArtifacts = new ArrayList<>();
 
         for ( String artifactDescriptor : bundles )
         {
-            logger.info( "Preparing remote bundle {}", artifactDescriptor );
+            getLog().info( "Preparing remote bundle " + artifactDescriptor );
             // groupId:artifactId:version[:type[:classifier]]
             String[] s = artifactDescriptor.split( ":" );
 
@@ -969,7 +966,7 @@ public abstract class AbstractProcessRemoteResourcesMojo
                 for ( MavenProject p : list )
                 {
                     if ( s[0].equals( p.getGroupId() ) && s[1].equals( p.getArtifactId() )
-                        && s[2].equals( p.getVersion() ) )
+                            && s[2].equals( p.getVersion() ) )
                     {
                         if ( s.length >= 4 && "test-jar".equals( s[3] ) )
                         {
@@ -1018,7 +1015,7 @@ public abstract class AbstractProcessRemoteResourcesMojo
     }
 
     private ClassLoader initalizeClassloader( List<File> artifacts )
-        throws MojoExecutionException
+            throws MojoExecutionException
     {
         RemoteResourcesClassLoader cl = new RemoteResourcesClassLoader( null );
         try
@@ -1036,10 +1033,10 @@ public abstract class AbstractProcessRemoteResourcesMojo
     }
 
     protected void processResourceBundles( ClassLoader classLoader, VelocityContext context )
-        throws MojoExecutionException
+            throws MojoExecutionException
     {
         List<Map.Entry<String, RemoteResourcesBundle>> remoteResources =
-            new ArrayList<>();
+                new ArrayList<>();
         int bundleCount = 0;
         int resourceCount = 0;
 
@@ -1049,14 +1046,14 @@ public abstract class AbstractProcessRemoteResourcesMojo
             RemoteResourcesBundleXpp3Reader bundleReader = new RemoteResourcesBundleXpp3Reader();
 
             for ( Enumeration<URL> e =
-                classLoader.getResources( BundleRemoteResourcesMojo.RESOURCES_MANIFEST ); e.hasMoreElements(); )
+                  classLoader.getResources( BundleRemoteResourcesMojo.RESOURCES_MANIFEST ); e.hasMoreElements(); )
             {
                 URL url = e.nextElement();
                 bundleCount++;
-                logger.debug( "processResourceBundle on bundle#{} {}", bundleCount, url );
+                getLog().debug( "processResourceBundle on bundle#" + bundleCount + " " + url );
 
                 RemoteResourcesBundle bundle;
-                
+
                 try ( InputStream in = url.openStream() )
                 {
                     bundle = bundleReader.read( in );
@@ -1067,7 +1064,7 @@ public abstract class AbstractProcessRemoteResourcesMojo
                 {
                     n++;
                     resourceCount++;
-                    logger.debug( "bundle#{} resource#{} {}", bundleCount, n, bundleResource );
+                    getLog().debug( "bundle#" + bundleCount + " resource#" + n + " " + bundleResource );
                     remoteResources.add( new AbstractMap.SimpleEntry<>( bundleResource, bundle ) );
                 }
             }
@@ -1081,8 +1078,9 @@ public abstract class AbstractProcessRemoteResourcesMojo
             throw new MojoExecutionException( "Error parsing remote resource bundle descriptor.", xppe );
         }
 
-        logger.info( "Copying {} resource{} from {} bundle{}.",
-                resourceCount, ( resourceCount > 1 ) ? "s" : "", bundleCount, ( bundleCount > 1 ) ? "s" : "" );
+        getLog().info(
+                "Copying " + resourceCount + " resource" + ( ( resourceCount > 1 ) ? "s" : "" ) + " from " + bundleCount
+                        + " bundle" + ( ( bundleCount > 1 ) ? "s" : "" ) + "." );
 
         String velocityResource = null;
         try
@@ -1114,10 +1112,10 @@ public abstract class AbstractProcessRemoteResourcesMojo
                     if ( doVelocity )
                     {
                         try ( DeferredFileOutputStream os =
-                                        new DeferredFileOutputStream( velocityFilterInMemoryThreshold, f ) )
+                                      new DeferredFileOutputStream( velocityFilterInMemoryThreshold, f ) )
                         {
                             try ( Writer writer = bundle.getSourceEncoding() == null ? new OutputStreamWriter( os )
-                                            : new OutputStreamWriter( os, bundle.getSourceEncoding() ) )
+                                    : new OutputStreamWriter( os, bundle.getSourceEncoding() ) )
                             {
                                 if ( bundle.getSourceEncoding() == null )
                                 {
@@ -1128,7 +1126,7 @@ public abstract class AbstractProcessRemoteResourcesMojo
                                 else
                                 {
                                     velocity.mergeTemplate( bundleResource, bundle.getSourceEncoding(), context,
-                                                            writer );
+                                            writer );
                                 }
                             }
                             fileWriteIfDiffers( os );
@@ -1148,20 +1146,20 @@ public abstract class AbstractProcessRemoteResourcesMojo
 
                     if ( appendedResourceFile.exists() )
                     {
-                        logger.info( "Copying appended resource: {}", projectResource );
+                        getLog().info( "Copying appended resource: " + projectResource );
                         try ( InputStream in = Files.newInputStream( appendedResourceFile.toPath() );
                               OutputStream out = new FileOutputStream( f, true ) )
                         {
                             IOUtil.copy( in, out );
                         }
-                        
+
                     }
                     else if ( appendedVmResourceFile.exists() )
                     {
-                        logger.info( "Filtering appended resource: {}.vm", projectResource );
-                        
+                        getLog().info( "Filtering appended resource: " + projectResource + ".vm" );
 
-                        try ( Reader reader = new FileReader( appendedVmResourceFile ); 
+
+                        try ( Reader reader = new FileReader( appendedVmResourceFile );
                               Writer writer = getWriter( bundle, f ) )
                         {
                             Velocity.init();
@@ -1182,7 +1180,7 @@ public abstract class AbstractProcessRemoteResourcesMojo
     }
 
     private Writer getWriter( RemoteResourcesBundle bundle, File f )
-        throws IOException
+            throws IOException
     {
         Writer writer;
         if ( bundle.getSourceEncoding() == null )
@@ -1192,13 +1190,13 @@ public abstract class AbstractProcessRemoteResourcesMojo
         else
         {
             writer = new PrintWriter( new OutputStreamWriter( new FileOutputStream( f, true ),
-                                                              bundle.getSourceEncoding() ) );
+                    bundle.getSourceEncoding() ) );
         }
         return writer;
     }
 
     protected Model getSupplement( Xpp3Dom supplementModelXml )
-        throws MojoExecutionException
+            throws MojoExecutionException
     {
         MavenXpp3Reader modelReader = new MavenXpp3Reader();
         Model model = null;
@@ -1212,22 +1210,22 @@ public abstract class AbstractProcessRemoteResourcesMojo
             if ( groupId == null || groupId.trim().equals( "" ) )
             {
                 throw new MojoExecutionException( "Supplemental project XML "
-                    + "requires that a <groupId> element be present." );
+                        + "requires that a <groupId> element be present." );
             }
 
             if ( artifactId == null || artifactId.trim().equals( "" ) )
             {
                 throw new MojoExecutionException( "Supplemental project XML "
-                    + "requires that a <artifactId> element be present." );
+                        + "requires that a <artifactId> element be present." );
             }
         }
         catch ( IOException e )
         {
-            logger.warn( "Unable to read supplemental XML: {}", e.getMessage(), e );
+            getLog().warn( "Unable to read supplemental XML: " + e.getMessage(), e );
         }
         catch ( XmlPullParserException e )
         {
-            logger.warn( "Unable to parse supplemental XML: {}", e.getMessage(), e );
+            getLog().warn( "Unable to parse supplemental XML: " + e.getMessage(), e );
         }
 
         return model;
@@ -1245,18 +1243,18 @@ public abstract class AbstractProcessRemoteResourcesMojo
     }
 
     private Map<String, Model> loadSupplements( String[] models )
-        throws MojoExecutionException
+            throws MojoExecutionException
     {
         if ( models == null )
         {
-            logger.debug( "Supplemental data models won't be loaded. No models specified." );
+            getLog().debug( "Supplemental data models won't be loaded. No models specified." );
             return Collections.emptyMap();
         }
 
         List<Supplement> supplements = new ArrayList<>();
         for ( String set : models )
         {
-            logger.debug( "Preparing ruleset: {}", set );
+            getLog().debug( "Preparing ruleset: " + set );
             try
             {
                 File f = locator.getResourceAsFile( set, getLocationTemp( set ) );
@@ -1268,10 +1266,10 @@ public abstract class AbstractProcessRemoteResourcesMojo
                 if ( !f.canRead() )
                 {
                     throw new MojoExecutionException( "Supplemental data models won't be loaded. " + "File "
-                        + f.getAbsolutePath() + " cannot be read, check permissions on the file." );
+                            + f.getAbsolutePath() + " cannot be read, check permissions on the file." );
                 }
 
-                logger.debug( "Loading supplemental models from {}", f.getAbsolutePath() );
+                getLog().debug( "Loading supplemental models from " + f.getAbsolutePath() );
 
                 SupplementalDataModelXpp3Reader reader = new SupplementalDataModelXpp3Reader();
                 SupplementalDataModel supplementalModel = reader.read( new FileReader( f ) );
@@ -1280,12 +1278,12 @@ public abstract class AbstractProcessRemoteResourcesMojo
             catch ( Exception e )
             {
                 String msg = "Error loading supplemental data models: " + e.getMessage();
-                logger.error( msg, e );
+                getLog().error( msg, e );
                 throw new MojoExecutionException( msg, e );
             }
         }
 
-        logger.debug( "Loading supplements complete." );
+        getLog().debug( "Loading supplements complete." );
 
         Map<String, Model> supplementMap = new HashMap<>();
         for ( Supplement sd : supplements )
@@ -1316,12 +1314,12 @@ public abstract class AbstractProcessRemoteResourcesMojo
         {
             loc = loc.substring( loc.lastIndexOf( '\\' ) + 1 );
         }
-        logger.debug( "Before: {} After: {}", name, loc );
+        getLog().debug( "Before: " + name + " After: " + loc );
         return loc;
     }
 
     static class OrganizationComparator
-        implements Comparator<Organization>
+            implements Comparator<Organization>
     {
         @Override
         public int compare( Organization org1, Organization org2 )
@@ -1354,7 +1352,7 @@ public abstract class AbstractProcessRemoteResourcesMojo
     }
 
     static class ProjectComparator
-        implements Comparator<MavenProject>
+            implements Comparator<MavenProject>
     {
         @Override
         public int compare( MavenProject p1, MavenProject p2 )

--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -350,7 +350,7 @@ public abstract class AbstractProcessRemoteResourcesMojo
     private String outputTimestamp;
 
     @Component
-    protected RepositorySystem repositorySystem;
+    protected RepositorySystem repoSystem;
 
     /**
      * Filtering support, for local resources that override those in the remote bundle.
@@ -990,9 +990,9 @@ public abstract class AbstractProcessRemoteResourcesMojo
                 {
                     ArtifactRequest request = new ArtifactRequest(
                             artifact,
-                            RepositoryUtils.toRepos( project.getRemoteArtifactRepositories() ),
+                            project.getRemoteProjectRepositories(),
                             "remote-resources" );
-                    ArtifactResult result = repositorySystem.resolveArtifact(
+                    ArtifactResult result = repoSystem.resolveArtifact(
                             mavenSession.getRepositorySession(), request );
                     artifactFile = result.getArtifact().getFile();
                 }

--- a/src/main/java/org/apache/maven/plugin/resources/remote/AggregateProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AggregateProcessRemoteResourcesMojo.java
@@ -40,12 +40,12 @@ import org.apache.maven.project.MavenProject;
  * </p>
  * Resources that don't end in ".vm" are copied "as is".
  */
-@Mojo( name = "aggregator-process",
+@Mojo( name = "aggregate",
        defaultPhase = LifecyclePhase.GENERATE_RESOURCES,
        aggregator = true,
        requiresDependencyResolution = ResolutionScope.TEST,
        threadSafe = true )
-public class AggregatorProcessRemoteResourcesMojo
+public class AggregateProcessRemoteResourcesMojo
     extends AbstractProcessRemoteResourcesMojo
 {
     @Override

--- a/src/main/java/org/apache/maven/plugin/resources/remote/AggregatorProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AggregatorProcessRemoteResourcesMojo.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.artifact.ProjectArtifact;
 
@@ -44,6 +45,7 @@ import org.apache.maven.project.artifact.ProjectArtifact;
 @Mojo( name = "aggregator-process",
        defaultPhase = LifecyclePhase.GENERATE_RESOURCES,
        aggregator = true,
+       requiresDependencyResolution = ResolutionScope.TEST,
        threadSafe = true )
 public class AggregatorProcessRemoteResourcesMojo
     extends AbstractProcessRemoteResourcesMojo

--- a/src/main/java/org/apache/maven/plugin/resources/remote/AggregatorProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AggregatorProcessRemoteResourcesMojo.java
@@ -21,14 +21,12 @@ package org.apache.maven.plugin.resources.remote;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.artifact.ProjectArtifact;
 
 /**
  * <p>
@@ -50,12 +48,6 @@ import org.apache.maven.project.artifact.ProjectArtifact;
 public class AggregatorProcessRemoteResourcesMojo
     extends AbstractProcessRemoteResourcesMojo
 {
-    @Override
-    protected Set<Artifact> getProjectArtifacts()
-    {
-        return mavenSession.getProjects().stream().map( ProjectArtifact::new ).collect( Collectors.toSet() );
-    }
-
     @Override
     protected Set<Artifact> getAllDependencies()
     {

--- a/src/main/java/org/apache/maven/plugin/resources/remote/ProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/ProcessRemoteResourcesMojo.java
@@ -58,7 +58,6 @@ import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.lifecycle.internal.LifecycleDependencyResolver;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Organization;
 import org.apache.maven.model.Resource;
@@ -369,9 +368,6 @@ public class ProcessRemoteResourcesMojo
     @Parameter( defaultValue = "${project.build.outputTimestamp}" )
     private String outputTimestamp;
 
-    /**
-     * Repository system, needed to create Artifact and Repository objects.
-     */
     @Component
     protected RepositorySystem repositorySystem;
 
@@ -381,8 +377,6 @@ public class ProcessRemoteResourcesMojo
     @Component
     private MavenFileFilter fileFilter;
 
-    /**
-     */
     @Component
     private ResourceManager locator;
 
@@ -397,13 +391,6 @@ public class ProcessRemoteResourcesMojo
      */
     @Component
     private ArtifactFactory artifactFactory;
-
-    /**
-     * TODO: this is fishy, the all thing that this Mojo does not require depResolution is fishy. Aggregated stuff
-     * (reason why it DOES NOT DO IT) should be separate mojo just like for any other Mojo.
-     */
-    @Component
-    private LifecycleDependencyResolver lifecycleDependencyResolver;
 
     /**
      * Map of artifacts to supplemental project object models.

--- a/src/main/java/org/apache/maven/plugin/resources/remote/ProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/ProcessRemoteResourcesMojo.java
@@ -50,18 +50,18 @@ public class ProcessRemoteResourcesMojo
     @Override
     protected Set<Artifact> getProjectArtifacts()
     {
-        return Collections.singleton( new ProjectArtifact( mavenSession.getCurrentProject() ) );
+        return Collections.singleton( new ProjectArtifact( project ) );
     }
 
     @Override
     protected Set<Artifact> getAllDependencies()
     {
-        return mavenSession.getCurrentProject().getArtifacts();
+        return project.getArtifacts();
     }
 
     @Override
     protected Set<Artifact> getDirectDependencies()
     {
-        return mavenSession.getCurrentProject().getDependencyArtifacts();
+        return project.getDependencyArtifacts();
     }
 }

--- a/src/main/java/org/apache/maven/plugin/resources/remote/ProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/ProcessRemoteResourcesMojo.java
@@ -19,14 +19,12 @@ package org.apache.maven.plugin.resources.remote;
  * under the License.
  */
 
-import java.util.Collections;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.apache.maven.project.artifact.ProjectArtifact;
 
 /**
  * <p>
@@ -47,12 +45,6 @@ import org.apache.maven.project.artifact.ProjectArtifact;
 public class ProcessRemoteResourcesMojo
     extends AbstractProcessRemoteResourcesMojo
 {
-    @Override
-    protected Set<Artifact> getProjectArtifacts()
-    {
-        return Collections.singleton( new ProjectArtifact( project ) );
-    }
-
     @Override
     protected Set<Artifact> getAllDependencies()
     {

--- a/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
@@ -538,7 +538,7 @@ public class RemoteResourcesMojoTest
 
     private String pathOf( Artifact artifact )
     {
-        String path = LOCAL_REPO + artifact.getGroupId().replaceAll( "\\.", "/" ) + "/"
+        String path = LOCAL_REPO + artifact.getGroupId().replace( ".", "/" ) + "/"
                 + artifact.getArtifactId() + "/"
                 + artifact.getBaseVersion() + "/"
                 + artifact.getArtifactId() + "-" + artifact.getVersion();

--- a/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
@@ -19,20 +19,6 @@ package org.apache.maven.plugin.resources.remote;
  * under the License.
  */
 
-import org.apache.maven.artifact.DefaultArtifact;
-import org.apache.maven.artifact.handler.DefaultArtifactHandler;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.versioning.VersionRange;
-import org.apache.maven.execution.DefaultMavenExecutionRequest;
-import org.apache.maven.execution.DefaultMavenExecutionResult;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.resources.remote.stub.MavenProjectBuildStub;
-import org.apache.maven.plugin.resources.remote.stub.MavenProjectResourcesStub;
-import org.apache.maven.plugin.testing.AbstractMojoTestCase;
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
-import org.codehaus.plexus.util.FileUtils;
-
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -45,6 +31,23 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.repository.MavenArtifactRepository;
+import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.DefaultMavenExecutionResult;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.resources.remote.stub.MavenProjectBuildStub;
+import org.apache.maven.plugin.resources.remote.stub.MavenProjectResourcesStub;
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.LocalArtifactRepository;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
@@ -55,7 +58,7 @@ import org.eclipse.aether.repository.LocalRepository;
  * RemoteResources plugin Test Case
  */
 public class RemoteResourcesMojoTest
-    extends AbstractMojoTestCase
+        extends AbstractMojoTestCase
 {
     static final String DEFAULT_BUNDLE_POM_PATH = "target/test-classes/unit/rrmojotest/bundle-plugin-config.xml";
     static final String DEFAULT_PROCESS_POM_PATH = "target/test-classes/unit/rrmojotest/process-plugin-config.xml";
@@ -64,14 +67,14 @@ public class RemoteResourcesMojoTest
 
     @Override
     public void setUp()
-        throws Exception
+            throws Exception
     {
         super.setUp();
     }
 
     @Override
     public void tearDown()
-        throws Exception
+            throws Exception
     {
 
     }
@@ -82,7 +85,7 @@ public class RemoteResourcesMojoTest
      * @throws Exception if any exception occurs
      */
     public void testTestEnvironment()
-        throws Exception
+            throws Exception
     {
         // Perform lookup on the Mojo to make sure everything is ok
         lookupProcessMojo();
@@ -90,7 +93,7 @@ public class RemoteResourcesMojoTest
 
 
     public void testNoBundles()
-        throws Exception
+            throws Exception
     {
         final MavenProjectResourcesStub project = createTestProject( "default-nobundles" );
         final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithDefaultSettings( project );
@@ -101,40 +104,39 @@ public class RemoteResourcesMojoTest
     }
 
     public void testCreateBundle()
-        throws Exception
+            throws Exception
     {
         buildResourceBundle( "default-createbundle",
-                            null,
-                            new String[] { "SIMPLE.txt" },
-                            null );
+                null,
+                new String[] {"SIMPLE.txt"},
+                null );
     }
 
     public void testSimpleBundles()
-        throws Exception
+            throws Exception
     {
         final MavenProjectResourcesStub project = createTestProject( "default-simplebundles" );
-        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings( project ,
-                                                                        new String[] {
-                                                                            "test:test:1.0"
-                                                                        } );
+        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings( project,
+                new String[] {
+                        "test:test:1.0"
+                } );
 
         setupDefaultProject( project );
 
-        ArtifactRepository repo = (ArtifactRepository) getVariableValueFromObject( mojo, "localRepository" );
-        String path = repo.pathOf( new DefaultArtifact( "test",
-                                                        "test",
-                                                        VersionRange.createFromVersion( "1.0" ),
-                                                        null,
-                                                        "jar",
-                                                        "",
-                                                        new DefaultArtifactHandler() ) );
+        String path = pathOf( new DefaultArtifact( "test",
+                "test",
+                VersionRange.createFromVersion( "1.0" ),
+                null,
+                "jar",
+                "",
+                new DefaultArtifactHandler() ) );
 
-        File file = new File( repo.getBasedir() + "/" + path + ".jar" );
+        File file = new File( path );
         file.getParentFile().mkdirs();
         buildResourceBundle( "default-simplebundles-create",
-                             null,
-                             new String[] { "SIMPLE.txt" },
-                             file );
+                null,
+                new String[] {"SIMPLE.txt"},
+                file );
 
 
         mojo.execute();
@@ -145,31 +147,30 @@ public class RemoteResourcesMojoTest
     }
 
     public void testSimpleBundlesWithType()
-        throws Exception
+            throws Exception
     {
         final MavenProjectResourcesStub project = createTestProject( "default-simplebundles" );
-        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings( project ,
-                                                                        new String[] {
-                                                                            "test:test:1.0:war"
-                                                                        } );
+        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings( project,
+                new String[] {
+                        "test:test:1.0:war"
+                } );
 
         setupDefaultProject( project );
 
-        ArtifactRepository repo = (ArtifactRepository) getVariableValueFromObject( mojo, "localRepository" );
-        String path = repo.pathOf( new DefaultArtifact( "test",
-                                                        "test",
-                                                        VersionRange.createFromVersion( "1.0" ),
-                                                        null,
-                                                        "war",
-                                                        "",
-                                                        new DefaultArtifactHandler() ) );
+        String path = pathOf( new DefaultArtifact( "test",
+                "test",
+                VersionRange.createFromVersion( "1.0" ),
+                null,
+                "war",
+                "",
+                new DefaultArtifactHandler() ) );
 
-        File file = new File( repo.getBasedir() + "/" + path + ".war" );
+        File file = new File( path );
         file.getParentFile().mkdirs();
         buildResourceBundle( "default-simplebundles-create",
-                             null,
-                             new String[] { "SIMPLE.txt" },
-                             file );
+                null,
+                new String[] {"SIMPLE.txt"},
+                file );
 
 
         mojo.execute();
@@ -180,31 +181,30 @@ public class RemoteResourcesMojoTest
     }
 
     public void testSimpleBundlesWithClassifier()
-        throws Exception
+            throws Exception
     {
         final MavenProjectResourcesStub project = createTestProject( "default-simplebundles" );
-        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings( project ,
-                                                                        new String[] {
-                                                                            "test:test:1.0:jar:test"
-                                                                        } );
+        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings( project,
+                new String[] {
+                        "test:test:1.0:jar:test"
+                } );
 
         setupDefaultProject( project );
 
-        ArtifactRepository repo = (ArtifactRepository) getVariableValueFromObject( mojo, "localRepository" );
-        String path = repo.pathOf( new DefaultArtifact( "test",
-                                                        "test",
-                                                        VersionRange.createFromVersion( "1.0" ),
-                                                        null,
-                                                        "jar",
-                                                        "test",
-                                                        new DefaultArtifactHandler() ) );
+        String path = pathOf( new DefaultArtifact( "test",
+                "test",
+                VersionRange.createFromVersion( "1.0" ),
+                null,
+                "jar",
+                "test",
+                new DefaultArtifactHandler() ) );
 
-        File file = new File( repo.getBasedir() + "/" + path + ".jar" );
+        File file = new File( path );
         file.getParentFile().mkdirs();
         buildResourceBundle( "default-simplebundles-create",
-                             null,
-                             new String[] { "SIMPLE.txt" },
-                             file );
+                null,
+                new String[] {"SIMPLE.txt"},
+                file );
 
 
         mojo.execute();
@@ -215,31 +215,30 @@ public class RemoteResourcesMojoTest
     }
 
     public void testVelocityUTF8()
-        throws Exception
+            throws Exception
     {
         final MavenProjectResourcesStub project = createTestProject( "default-utf8" );
-        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings( project ,
-                                                                        new String[] {
-                                                                            "test:test:1.2"
-                                                                        } );
+        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings( project,
+                new String[] {
+                        "test:test:1.2"
+                } );
 
         setupDefaultProject( project );
 
-        ArtifactRepository repo = (ArtifactRepository) getVariableValueFromObject( mojo, "localRepository" );
-        String path = repo.pathOf( new DefaultArtifact( "test",
-                                                        "test",
-                                                        VersionRange.createFromVersion( "1.2" ),
-                                                        null,
-                                                        "jar",
-                                                        "",
-                                                        new DefaultArtifactHandler() ) );
+        String path = pathOf( new DefaultArtifact( "test",
+                "test",
+                VersionRange.createFromVersion( "1.2" ),
+                null,
+                "jar",
+                "",
+                new DefaultArtifactHandler() ) );
 
-        File file = new File( repo.getBasedir() + "/" + path + ".jar" );
+        File file = new File( path );
         file.getParentFile().mkdirs();
         buildResourceBundle( "default-utf8-create",
-                             "UTF-8",
-                             new String[] { "UTF-8.bin.vm" },
-                             file );
+                "UTF-8",
+                new String[] {"UTF-8.bin.vm"},
+                file );
 
         mojo.execute();
 
@@ -247,7 +246,7 @@ public class RemoteResourcesMojoTest
         file = new File( file, "UTF-8.bin" );
         assertTrue( file.exists() );
 
-        try (InputStream in = Files.newInputStream( file.toPath( ) ) )
+        try ( InputStream in = Files.newInputStream( file.toPath() ) )
         {
             byte[] data = IOUtil.toByteArray( in );
             byte[] expected = "\u00E4\u00F6\u00FC\u00C4\u00D6\u00DC\u00DF".getBytes( StandardCharsets.UTF_8 );
@@ -256,31 +255,30 @@ public class RemoteResourcesMojoTest
     }
 
     public void testVelocityISO88591()
-        throws Exception
+            throws Exception
     {
         final MavenProjectResourcesStub project = createTestProject( "default-iso88591" );
-        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings( project ,
-                                                                        new String[] {
-                                                                            "test:test:1.3"
-                                                                        } );
+        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings( project,
+                new String[] {
+                        "test:test:1.3"
+                } );
 
         setupDefaultProject( project );
 
-        ArtifactRepository repo = (ArtifactRepository) getVariableValueFromObject( mojo, "localRepository" );
-        String path = repo.pathOf( new DefaultArtifact( "test",
-                                                        "test",
-                                                        VersionRange.createFromVersion( "1.3" ),
-                                                        null,
-                                                        "jar",
-                                                        "",
-                                                        new DefaultArtifactHandler() ) );
+        String path = pathOf( new DefaultArtifact( "test",
+                "test",
+                VersionRange.createFromVersion( "1.3" ),
+                null,
+                "jar",
+                "",
+                new DefaultArtifactHandler() ) );
 
-        File file = new File( repo.getBasedir() + "/" + path + ".jar" );
+        File file = new File( path );
         file.getParentFile().mkdirs();
         buildResourceBundle( "default-iso88591-create",
-                             "ISO-8859-1",
-                             new String[] { "ISO-8859-1.bin.vm" },
-                             file );
+                "ISO-8859-1",
+                new String[] {"ISO-8859-1.bin.vm"},
+                file );
 
         mojo.execute();
 
@@ -288,7 +286,7 @@ public class RemoteResourcesMojoTest
         file = new File( file, "ISO-8859-1.bin" );
         assertTrue( file.exists() );
 
-        try (InputStream in = Files.newInputStream( file.toPath() ) )
+        try ( InputStream in = Files.newInputStream( file.toPath() ) )
         {
             byte[] data = IOUtil.toByteArray( in );
             byte[] expected = "\u00E4\u00F6\u00FC\u00C4\u00D6\u00DC\u00DF".getBytes( StandardCharsets.ISO_8859_1 );
@@ -298,31 +296,30 @@ public class RemoteResourcesMojoTest
     }
 
     public void testFilteredBundles()
-        throws Exception
+            throws Exception
     {
         final MavenProjectResourcesStub project = createTestProject( "default-filterbundles" );
-        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings( project ,
-                                                                        new String[] {
-                                                                            "test:test:1.1"
-                                                                        } );
+        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings( project,
+                new String[] {
+                        "test:test:1.1"
+                } );
 
         setupDefaultProject( project );
 
-        ArtifactRepository repo = (ArtifactRepository) getVariableValueFromObject( mojo, "localRepository" );
-        String path = repo.pathOf( new DefaultArtifact( "test",
-                                                        "test",
-                                                        VersionRange.createFromVersion( "1.1" ),
-                                                        null,
-                                                        "jar",
-                                                        "",
-                                                        new DefaultArtifactHandler() ) );
+        String path = pathOf( new DefaultArtifact( "test",
+                "test",
+                VersionRange.createFromVersion( "1.1" ),
+                null,
+                "jar",
+                "",
+                new DefaultArtifactHandler() ) );
 
-        File file = new File( repo.getBasedir() + "/" + path + ".jar" );
+        File file = new File( path );
         file.getParentFile().mkdirs();
         buildResourceBundle( "default-filterbundles-create",
-                             null,
-                             new String[] { "FILTER.txt.vm" },
-                             file );
+                null,
+                new String[] {"FILTER.txt.vm"},
+                file );
 
 
         mojo.execute();
@@ -341,11 +338,12 @@ public class RemoteResourcesMojoTest
     }
 
     public void testFilteredBundlesWithProjectProperties()
-      throws Exception
+            throws Exception
     {
         final MavenProjectResourcesStub project = createTestProject( "default-filterbundles-two" );
         final ProcessRemoteResourcesMojo mojo =
-            lookupProcessMojoWithSettings( project, new String[]{"test-filtered-bundles:test-filtered-bundles:2"} );
+                lookupProcessMojoWithSettings( project,
+                        new String[] {"test-filtered-bundles:test-filtered-bundles:2"} );
 
         mojo.includeProjectProperties = true;
         setupDefaultProject( project );
@@ -353,14 +351,13 @@ public class RemoteResourcesMojoTest
         project.addProperty( "testingPropertyOne", "maven" );
         project.addProperty( "testingPropertyTwo", "rules" );
 
-        ArtifactRepository repo = (ArtifactRepository) getVariableValueFromObject( mojo, "localRepository" );
-        String path = repo.pathOf( new DefaultArtifact( "test-filtered-bundles", "test-filtered-bundles",
-                                                        VersionRange.createFromVersion( "2" ), null, "jar", "",
-                                                        new DefaultArtifactHandler() ) );
+        String path = pathOf( new DefaultArtifact( "test-filtered-bundles", "test-filtered-bundles",
+                VersionRange.createFromVersion( "2" ), null, "jar", "",
+                new DefaultArtifactHandler() ) );
 
-        File file = new File( repo.getBasedir() + "/" + path + ".jar" );
+        File file = new File( path );
         file.getParentFile().mkdirs();
-        buildResourceBundle( "default-filterbundles-two-create", null, new String[]{"PROPERTIES.txt.vm"}, file );
+        buildResourceBundle( "default-filterbundles-two-create", null, new String[] {"PROPERTIES.txt.vm"}, file );
 
         mojo.execute();
         // executing a second time (example: forked lifecycle) should still work
@@ -372,20 +369,20 @@ public class RemoteResourcesMojoTest
         assertTrue( file.exists() );
 
         String data = FileUtils.fileRead( file );
-        assertTrue(data.contains("maven"));
-        assertTrue(data.contains("rules"));
+        assertTrue( data.contains( "maven" ) );
+        assertTrue( data.contains( "rules" ) );
     }
 
     protected void buildResourceBundle( String id,
-                                       String sourceEncoding,
-                                       String[] resourceNames,
-                                       File jarName )
-    throws Exception
+                                        String sourceEncoding,
+                                        String[] resourceNames,
+                                        File jarName )
+            throws Exception
     {
         final MavenProjectResourcesStub project = createTestProject( id );
 
         final File resourceDir = new File( project.getBasedir() + "/src/main/resources" );
-        final BundleRemoteResourcesMojo mojo = lookupBundleMojoWithSettings( project , resourceDir, sourceEncoding );
+        final BundleRemoteResourcesMojo mojo = lookupBundleMojoWithSettings( project, resourceDir, sourceEncoding );
 
         setupDefaultProject( project );
 
@@ -394,7 +391,7 @@ public class RemoteResourcesMojoTest
             File resource = new File( resourceDir, resourceName2 );
             URL source = getClass().getResource( "/" + resourceName2 );
 
-            FileUtils.copyURLToFile(source, resource);
+            FileUtils.copyURLToFile( source, resource );
         }
 
         mojo.execute();
@@ -432,9 +429,8 @@ public class RemoteResourcesMojoTest
     }
 
 
-
     protected MavenProjectResourcesStub createTestProject( final String testName )
-    throws Exception
+            throws Exception
     {
         // this will automatically create the isolated
         // test environment
@@ -442,7 +438,7 @@ public class RemoteResourcesMojoTest
     }
 
     protected void setupDefaultProject( final MavenProjectResourcesStub project )
-    throws Exception
+            throws Exception
     {
         // put this on the root dir
         project.addFile( "pom.xml", MavenProjectBuildStub.ROOT_FILE );
@@ -453,7 +449,7 @@ public class RemoteResourcesMojoTest
 
 
     protected BundleRemoteResourcesMojo lookupBundleMojo()
-    throws Exception
+            throws Exception
     {
         File pomFile = new File( getBasedir(), DEFAULT_BUNDLE_POM_PATH );
         BundleRemoteResourcesMojo mojo = (BundleRemoteResourcesMojo) lookupMojo( "bundle", pomFile );
@@ -464,7 +460,7 @@ public class RemoteResourcesMojoTest
     }
 
     protected BundleRemoteResourcesMojo lookupBundleMojoWithDefaultSettings( final MavenProject project )
-        throws Exception
+            throws Exception
     {
         File resourceDir = new File( project.getBasedir() + "/src/main/resources" );
         return lookupBundleMojoWithSettings( project, resourceDir, null );
@@ -472,7 +468,7 @@ public class RemoteResourcesMojoTest
 
     protected BundleRemoteResourcesMojo lookupBundleMojoWithSettings( final MavenProject project,
                                                                       File resourceDir, String sourceEncoding )
-    throws Exception
+            throws Exception
     {
         final BundleRemoteResourcesMojo mojo = lookupBundleMojo();
 
@@ -483,7 +479,7 @@ public class RemoteResourcesMojoTest
     }
 
     protected ProcessRemoteResourcesMojo lookupProcessMojo()
-        throws Exception
+            throws Exception
     {
         File pomFile = new File( getBasedir(), DEFAULT_PROCESS_POM_PATH );
         ProcessRemoteResourcesMojo mojo = (ProcessRemoteResourcesMojo) lookupMojo( "process", pomFile );
@@ -495,46 +491,66 @@ public class RemoteResourcesMojoTest
 
 
     protected ProcessRemoteResourcesMojo lookupProcessMojoWithSettings( final MavenProject project,
-                                                                 String[] bundles )
-        throws Exception
+                                                                        String[] bundles )
+            throws Exception
     {
         return lookupProcessMojoWithSettings( project, new ArrayList<>( Arrays.asList( bundles ) ) );
     }
 
     protected ProcessRemoteResourcesMojo lookupProcessMojoWithSettings( final MavenProject project,
-                                                                 ArrayList<String> bundles )
-        throws Exception
+                                                                        ArrayList<String> bundles )
+            throws Exception
     {
         final ProcessRemoteResourcesMojo mojo = lookupProcessMojo();
 
-        ArtifactRepository localRepository = mojo.repositorySystem.createLocalRepository( new File( LOCAL_REPO ) );
         DefaultRepositorySystemSession reposession = MavenRepositorySystemUtils.newSession();
         reposession.setLocalRepositoryManager( new SimpleLocalRepositoryManagerFactory()
                 .newInstance( reposession, new LocalRepository( new File( LOCAL_REPO ) ) ) );
 
         DefaultMavenExecutionRequest request = new DefaultMavenExecutionRequest();
-        request.setLocalRepository( localRepository );
-        request = new DefaultMavenExecutionRequest();
         request.setUserProperties( null );
-        request.setLocalRepository( localRepository );
-        request.setGoals(Collections.singletonList( "install" ) );
+        //request.setLocalRepository( reposession.getLocalRepository() );
+        request.setGoals( Collections.singletonList( "install" ) );
         request.setBaseDirectory( project.getBasedir() );
         request.setStartTime( Calendar.getInstance().getTime() );
-        MavenSession session = new MavenSession( getContainer(), reposession, request, new DefaultMavenExecutionResult() );
+
+        // TODO: get rid of this uglyness/legacy
+        MavenArtifactRepository localRepository = new MavenArtifactRepository();
+        localRepository.setId( "local" );
+        localRepository.setUrl( new File( LOCAL_REPO ).toURI().toASCIIString() );
+        localRepository.setLayout( new DefaultRepositoryLayout() );
+        request.setLocalRepository( localRepository );
+        MavenSession session =
+                new MavenSession( getContainer(), reposession, request, new DefaultMavenExecutionResult() );
         session.setProjects( Collections.singletonList( project ) );
 
-        setVariableValueToObject( mojo, "project", project );
         setVariableValueToObject( mojo, "outputDirectory", new File( project.getBuild().getOutputDirectory() ) );
         setVariableValueToObject( mojo, "resourceBundles", bundles );
         setVariableValueToObject( mojo, "mavenSession", session );
-        setVariableValueToObject( mojo, "remoteArtifactRepositories", project.getRemoteArtifactRepositories() );
-        setVariableValueToObject( mojo, "resources", project.getResources() );
         return mojo;
     }
 
     protected ProcessRemoteResourcesMojo lookupProcessMojoWithDefaultSettings( final MavenProject project )
-        throws Exception
+            throws Exception
     {
         return lookupProcessMojoWithSettings( project, new ArrayList<>() );
+    }
+
+    private String pathOf( Artifact artifact )
+    {
+        String path = LOCAL_REPO + artifact.getGroupId().replaceAll( "\\.", "/" ) + "/"
+                + artifact.getArtifactId() + "/"
+                + artifact.getBaseVersion() + "/"
+                + artifact.getArtifactId() + "-" + artifact.getVersion();
+        if ( artifact.getClassifier() != null && !artifact.getClassifier().isEmpty() )
+        {
+            path = path + "-" + artifact.getClassifier();
+        }
+        String ext = artifact.getArtifactHandler().getExtension();
+        if ( ext == null ) {
+            ext = artifact.getType();
+        }
+        path = path + "." + ext;
+        return path;
     }
 }

--- a/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
@@ -45,7 +45,6 @@ import org.apache.maven.plugin.resources.remote.stub.MavenProjectBuildStub;
 import org.apache.maven.plugin.resources.remote.stub.MavenProjectResourcesStub;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.repository.LocalArtifactRepository;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;

--- a/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
@@ -526,6 +526,7 @@ public class RemoteResourcesMojoTest
         setVariableValueToObject( mojo, "outputDirectory", new File( project.getBuild().getOutputDirectory() ) );
         setVariableValueToObject( mojo, "resourceBundles", bundles );
         setVariableValueToObject( mojo, "mavenSession", session );
+        setVariableValueToObject( mojo, "project", project );
         return mojo;
     }
 

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_BadDependencyPoms.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_BadDependencyPoms.java
@@ -21,9 +21,9 @@ package org.apache.maven.plugin.resources.remote.it;
 
 import static org.junit.Assert.assertTrue;
 
-import org.apache.maven.it.VerificationException;
-import org.apache.maven.it.Verifier;
 import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
 import org.junit.Test;
 

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_CustomFilterDelimiter.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_CustomFilterDelimiter.java
@@ -21,9 +21,9 @@ package org.apache.maven.plugin.resources.remote.it;
 
 import static org.junit.Assert.assertTrue;
 
-import org.apache.maven.it.VerificationException;
-import org.apache.maven.it.Verifier;
 import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
 import org.junit.Test;
 
@@ -41,11 +41,11 @@ public class IT_CustomFilterDelimiter
         File dir = TestUtils.getTestDir( "custom-filter-delim" );
         Verifier verifier = TestUtils.newVerifier( dir );
 
-        verifier.getCliOptions().add( "-X" );
+        verifier.addCliArgument( "-X" );
+        verifier.addCliArgument( "validate" );
 
-        verifier.executeGoal( "validate" );
+        verifier.execute();
         verifier.verifyErrorFreeLog();
-        verifier.resetStreams();
 
         File output = new File( dir, "target/maven-shared-archive-resources/DEPENDENCIES" );
         String content = FileUtils.fileRead( output );

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_FilterLocalOverride.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_FilterLocalOverride.java
@@ -21,9 +21,9 @@ package org.apache.maven.plugin.resources.remote.it;
 
 import static org.junit.Assert.assertTrue;
 
-import org.apache.maven.it.VerificationException;
-import org.apache.maven.it.Verifier;
 import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
 import org.junit.Test;
 
@@ -41,9 +41,9 @@ public class IT_FilterLocalOverride
         File dir = TestUtils.getTestDir( "filter-local-override" );
         Verifier verifier = TestUtils.newVerifier( dir );
 
-        verifier.executeGoal( "generate-resources" );
+        verifier.addCliArgument( "generate-resources" );
+        verifier.execute();
         verifier.verifyErrorFreeLog();
-        verifier.resetStreams();
 
         File output = new File( dir, "target/maven-shared-archive-resources/DEPENDENCIES" );
         String content = FileUtils.fileRead( output );

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_GenerateFromBundle.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_GenerateFromBundle.java
@@ -21,9 +21,9 @@ package org.apache.maven.plugin.resources.remote.it;
 
 import static org.junit.Assert.assertTrue;
 
-import org.apache.maven.it.VerificationException;
-import org.apache.maven.it.Verifier;
 import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
 import org.junit.Test;
 
@@ -41,9 +41,9 @@ public class IT_GenerateFromBundle
         File dir = TestUtils.getTestDir( "generate-from-bundle" );
         Verifier verifier = TestUtils.newVerifier( dir );
 
-        verifier.executeGoal( "generate-resources" );
+        verifier.addCliArgument( "generate-resources" );
+        verifier.execute();
         verifier.verifyErrorFreeLog();
-        verifier.resetStreams();
 
         File output = new File( dir, "target/maven-shared-archive-resources/DEPENDENCIES" );
         String content = FileUtils.fileRead( output );

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_GenerateFromBundleWithTypeAndClassifier.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_GenerateFromBundleWithTypeAndClassifier.java
@@ -21,9 +21,9 @@ package org.apache.maven.plugin.resources.remote.it;
 
 import static org.junit.Assert.assertTrue;
 
-import org.apache.maven.it.VerificationException;
-import org.apache.maven.it.Verifier;
 import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
 import org.junit.Test;
 
@@ -42,9 +42,9 @@ public class IT_GenerateFromBundleWithTypeAndClassifier
         File dir = TestUtils.getTestDir( "generate-from-bundle-with-type-and-classifier" );
         Verifier verifier = TestUtils.newVerifier( dir );
 
-        verifier.executeGoal( "generate-resources" );
+        verifier.addCliArgument( "generate-resources" );
+        verifier.execute();
         verifier.verifyErrorFreeLog();
-        verifier.resetStreams();
 
         File output = new File( dir, "target/maven-shared-archive-resources/DEPENDENCIES" );
         String content = FileUtils.fileRead( output );

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_GenerateFromOverride.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_GenerateFromOverride.java
@@ -21,9 +21,9 @@ package org.apache.maven.plugin.resources.remote.it;
 
 import static org.junit.Assert.assertTrue;
 
-import org.apache.maven.it.VerificationException;
-import org.apache.maven.it.Verifier;
 import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
 import org.junit.Test;
 
@@ -41,9 +41,9 @@ public class IT_GenerateFromOverride
         File dir = TestUtils.getTestDir( "generate-from-override" );
         Verifier verifier = TestUtils.newVerifier( dir );
 
-        verifier.executeGoal( "generate-resources" );
+        verifier.addCliArgument( "generate-resources" );
+        verifier.execute();
         verifier.verifyErrorFreeLog();
-        verifier.resetStreams();
 
         File output = new File( dir, "target/maven-shared-archive-resources/DEPENDENCIES" );
         String content = FileUtils.fileRead( output );

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_GetDependencyProjects.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_GetDependencyProjects.java
@@ -21,9 +21,9 @@ package org.apache.maven.plugin.resources.remote.it;
 
 import static org.junit.Assert.assertTrue;
 
-import org.apache.maven.it.VerificationException;
-import org.apache.maven.it.Verifier;
 import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
 import org.junit.Test;
 
@@ -46,9 +46,9 @@ public class IT_GetDependencyProjects
         Verifier verifier;
 
         verifier = TestUtils.newVerifier( dir );
-        verifier.executeGoal( "deploy" );
+        verifier.addCliArgument( "deploy" );
+        verifier.execute();
         verifier.verifyErrorFreeLog();
-        verifier.resetStreams();
 
         verifier = TestUtils.newVerifier( new File( dir, "project" ) );
 
@@ -56,12 +56,11 @@ public class IT_GetDependencyProjects
 
         try
         {
-            verifier.executeGoal( "generate-resources" );
+            verifier.addCliArgument( "generate-resources" );
+            verifier.execute();
         }
         catch ( VerificationException e)
         {
-            verifier.resetStreams();
-
             // We will get an exception from harness in case
             // of execution failure (return code non zero).
             // This is the case if we have missing artifacts
@@ -77,8 +76,5 @@ public class IT_GetDependencyProjects
             assertTrue( content.contains( "mvn install:install-file -DgroupId=org.apache.maven.plugin.rresource.it.gdp -DartifactId=release -Dversion=1.0 -Dpackaging=jar" ) );
             assertTrue( content.contains( "mvn install:install-file -DgroupId=org.apache.maven.plugin.rresource.it.gdp -DartifactId=snapshot -Dversion=1.0-SNAPSHOT -Dpackaging=jar" ) );
         }
-
-
     }
-
 }

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_RunOnlyAtExecutionRoot.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_RunOnlyAtExecutionRoot.java
@@ -23,9 +23,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
-import org.apache.maven.it.VerificationException;
-import org.apache.maven.it.Verifier;
 import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.Os;
 import org.junit.Test;
@@ -54,11 +54,10 @@ public class IT_RunOnlyAtExecutionRoot
         Verifier verifier;
 
         verifier = TestUtils.newVerifier( new File( dir, "resource-projects" ) );
-        verifier.executeGoal( "deploy" );
+        verifier.addCliArgument( "deploy" );
+        verifier.execute();
         verifier.setLogFileName( "first.log" );
-        verifier.displayStreamBuffers();
         verifier.verifyErrorFreeLog();
-        verifier.resetStreams();
 
         verifier = TestUtils.newVerifier( dir );
 
@@ -70,10 +69,9 @@ public class IT_RunOnlyAtExecutionRoot
         // Might reconsider how to write a better testcase.
         // verifier.deleteArtifacts( "org.apache.maven.plugin.rresource.it.mrr41" );
 
-        verifier.executeGoal( "generate-resources" );
-        verifier.displayStreamBuffers();
+        verifier.addCliArgument( "generate-resources" );
+        verifier.execute();
         verifier.verifyErrorFreeLog();
-        verifier.resetStreams();
 
         String depResource = "target/maven-shared-archive-resources/DEPENDENCIES";
         File output = new File( dir, depResource );

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_RunOnlyAtExecutionRoot.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_RunOnlyAtExecutionRoot.java
@@ -79,8 +79,8 @@ public class IT_RunOnlyAtExecutionRoot
         assertTrue( output.exists() );
 
         // aggregates in bulk, not per-child
-        //assertFalse( new File( dir, "child1/" + depResource ).exists() );
-        //assertFalse( new File( dir, "child2/" + depResource ).exists() );
+        assertFalse( new File( dir, "child1/" + depResource ).exists() );
+        assertFalse( new File( dir, "child2/" + depResource ).exists() );
 
         String content = FileUtils.fileRead( output );
 

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_RunOnlyAtExecutionRoot.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_RunOnlyAtExecutionRoot.java
@@ -69,7 +69,8 @@ public class IT_RunOnlyAtExecutionRoot
         // Might reconsider how to write a better testcase.
         // verifier.deleteArtifacts( "org.apache.maven.plugin.rresource.it.mrr41" );
 
-        verifier.addCliArgument( "generate-resources" );
+        // verifier.addCliArgument( "generate-resources" );
+        verifier.addCliArgument( "package" );
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
@@ -77,8 +78,9 @@ public class IT_RunOnlyAtExecutionRoot
         File output = new File( dir, depResource );
         assertTrue( output.exists() );
 
-        assertFalse( new File( dir, "child1/" + depResource ).exists() );
-        assertFalse( new File( dir, "child2/" + depResource ).exists() );
+        // aggregates in bulk, not per-child
+        //assertFalse( new File( dir, "child1/" + depResource ).exists() );
+        //assertFalse( new File( dir, "child2/" + depResource ).exists() );
 
         String content = FileUtils.fileRead( output );
 

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_SupplementalArtifact.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/IT_SupplementalArtifact.java
@@ -21,9 +21,9 @@ package org.apache.maven.plugin.resources.remote.it;
 
 import static org.junit.Assert.assertTrue;
 
-import org.apache.maven.it.VerificationException;
-import org.apache.maven.it.Verifier;
 import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
 import org.junit.Test;
 
@@ -50,15 +50,15 @@ public class IT_SupplementalArtifact
 
         verifier.deleteArtifacts( "org.apache.maven.plugin.rresource.it.mrr43" );
 
-        verifier.executeGoal( "deploy" );
+        verifier.addCliArgument( "deploy" );
+        verifier.execute();
         verifier.verifyErrorFreeLog();
-        verifier.resetStreams();
 
         verifier = TestUtils.newVerifier( dir );
 
-        verifier.executeGoal( "generate-resources" );
+        verifier.addCliArgument( "generate-resources" );
+        verifier.execute();
         verifier.verifyErrorFreeLog();
-        verifier.resetStreams();
 
         File output = new File( dir, "target/maven-shared-archive-resources/DEPENDENCIES" );
         String content = FileUtils.fileRead( output );

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/support/BootstrapInstaller.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/support/BootstrapInstaller.java
@@ -19,12 +19,13 @@ package org.apache.maven.plugin.resources.remote.it.support;
  * under the License.
  */
 
-import org.apache.maven.it.VerificationException;
-import org.apache.maven.it.Verifier;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.shared.verifier.Verifier;
 
 public class BootstrapInstaller
 {

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/support/TestUtils.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/support/TestUtils.java
@@ -25,8 +25,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
-import org.apache.maven.it.VerificationException;
-import org.apache.maven.it.Verifier;
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.shared.verifier.Verifier;
 
 public class TestUtils
 {

--- a/src/test/resources/unit/rrmojotest/process-plugin-config.xml
+++ b/src/test/resources/unit/rrmojotest/process-plugin-config.xml
@@ -24,7 +24,6 @@ under the License.
       <plugin>
         <artifactId>maven-remote-resources-plugin</artifactId>
         <configuration>
-          <localRepository>${localRepository}</localRepository>
           <encoding>UTF-8</encoding>
           <outputTimestamp>2019-12-31T12:00:00Z</outputTimestamp>
         </configuration>


### PR DESCRIPTION
Get rid of MAT, Maven 3.9.1 warning about `localRepository`, etc. Make Maven resolve and not Mojo, this gets rid of quite a lot code. For `runOnlyAtExecutionRoot` introduce new mojo `aggregate-process` that is aggregator Mojo.

So, with this PR:
* the existing `process` mojo does all as before, but is much simpler, but LOOSES `runOnlyAtExecutionRoot` parameter and functionality
* added new `aggregator-process` Mojo that does what `process` w/ `runOnlyAtExecutionRoot` before did with slight changes (in bulk output, that is IMHO acceptable).

---

https://issues.apache.org/jira/browse/MRRESOURCES-126