### PR TITLE
[MRRESOURCES-135] Show `projectTimespan` year in UTC

### DIFF
--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.TreeMap;
 
 import org.apache.commons.io.output.DeferredFileOutputStream;
@@ -804,7 +805,9 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
         Date outputDate = archiver.parseOutputTimestamp(outputTimestamp);
 
         String inceptionYear = project.getInceptionYear();
-        String year = new SimpleDateFormat("yyyy").format((outputDate == null) ? new Date() : outputDate);
+        SimpleDateFormat yearFormat = new SimpleDateFormat("yyyy");
+        yearFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        String year = yearFormat.format((outputDate == null) ? new Date() : outputDate);
 
         if (inceptionYear == null || inceptionYear.isEmpty()) {
             if (getLog().isDebugEnabled()) {

--- a/src/test/resources/unit/rrmojotest/process-plugin-config.xml
+++ b/src/test/resources/unit/rrmojotest/process-plugin-config.xml
@@ -25,7 +25,7 @@ under the License.
         <artifactId>maven-remote-resources-plugin</artifactId>
         <configuration>
           <encoding>UTF-8</encoding>
-          <outputTimestamp>2019-12-31T12:00:00Z</outputTimestamp>
+          <outputTimestamp>2019-01-01T00:00:00Z</outputTimestamp>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Show the 'current' year in the `projectTimespan` (used for example in https://github.com/apache/maven-apache-resources/blob/master/jar/src/main/resources/META-INF/NOTICE.vm#L21 ) in UTC.

By default, `SimpleDateFormat` formats the `java.util.Date` (which does not carry a timezone) in the 'current' timezone. This is not reproducible, as when `project.build.outputTimestamp` is set to a time close to new years', two builds in different timezones may produce a different year.

This change makes sure the year is shown in UTC. This especially makes sense when `project.build.outputTimestamp` is given in seconds since epoch, since epoch is defined to be given relative to 00:00:00 UTC on Thursday, 1 January 1970. It is also likely the most common timezone when specifying `project.build.outputTimestamp` as a date.

I did not introduce a new unit test to test this behaviour, but I did update an existing test to be more likely to fail in this case (specifically, when building with for example `TZ=GMT-7`).