### PR TITLE
MRESOURCES-311. Ensure reproducible order in bundle

### DIFF
--- a/src/main/java/org/apache/maven/plugin/resources/remote/BundleRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/BundleRemoteResourcesMojo.java
@@ -23,6 +23,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 import org.apache.maven.plugin.AbstractMojo;
@@ -106,6 +107,7 @@ public class BundleRemoteResourcesMojo extends AbstractMojo {
         remoteResourcesBundle.setSourceEncoding(sourceEncoding);
 
         DirectoryScanner scanner = new DirectoryScanner();
+        scanner.setFilenameComparator(Comparator.naturalOrder());
 
         scanner.setBasedir(resourcesDirectory);
         if (includes != null && includes.length != 0) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`remote-resources:bundle` creates output that may not be reproducible.

https://github.com/apache/maven-remote-resources-plugin/blob/7a40047813a7cfde0a1bfeedff66bdc76f7ea430/src/main/java/org/apache/maven/plugin/resources/remote/BundleRemoteResourcesMojo.java#L108-L122

`DirectoryScanner` uses `java.io.File.list()`, which does not guarantee order.

https://issues.apache.org/jira/browse/MRESOURCES-311

## How was this patch tested?

Built the plugin and used it in another project.  Changed `naturalOrder` to `reverseOrder`, and repeated.  Verified output is reversed between the two runs.