### PR TITLE
Rewrite documentation per ASD-STE100 Simplified Technical English

### DIFF
--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -9,75 +9,69 @@
 ~~ Licensed to the Apache Software Foundation (ASF) under one
 ~~ or more contributor license agreements.  See the NOTICE file
 ~~ distributed with this work for additional information
-~~ regarding copyright ownership.  The ASF licenses this file
+~~ regarding copyright ownership. The ASF licenses this file
 ~~ to you under the Apache License, Version 2.0 (the
 ~~ "License"); you may not use this file except in compliance
-~~ with the License.  You may obtain a copy of the License at
+~~ with the License. You may obtain a copy of the License at
 ~~
 ~~   http://www.apache.org/licenses/LICENSE-2.0
 ~~
 ~~ Unless required by applicable law or agreed to in writing,
 ~~ software distributed under the License is distributed on an
 ~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-~~ KIND, either express or implied.  See the License for the
+~~ KIND, either express or implied. See the License for the
 ~~ specific language governing permissions and limitations
 ~~ under the License.
 
 ${project.name}
 
-  This plugin is used to retrieve JARs of resources from remote repositories,
-  process those resources, and incorporate them into JARs you build with
-  Maven.
-  
-  A very common use-case is the need to package certain resources in a
-  consistent way across your organization. For example at Apache, it is required that every
-  JAR produced contains a copy of the Apache license and a notice file that
-  references all used software in a given project: see {{{/apache-resource-bundles/}Apache Resource Bundles}}.
+  This plugin retrieves JARs of resources from remote repositories,
+  processes those resources, and incorporates them into JARs you build with Maven.
+
+  A common use-case is packaging resources consistently across your organization.
+  At Apache, every JAR must contain a copy of the Apache license and a notice file
+  that references all used software in a given project: see {{{/apache-resource-bundles/}Apache Resource Bundles}}.
 
 * Goals Overview
 
-  * {{{./bundle-mojo.html}remote-resources:bundle}} creates the resource bundle manifest required
-    by the remote resource bundle processing. The {{{./remote-resources.html}manifest file}},
-    <<<$\{basedir\}/target/classes/META-INF/maven/remote-resources.xml>>>, is created from the contents of the
-    <<<src/main/resources>>> directory.
+  * {{{./bundle-mojo.html}remote-resources:bundle}} creates the resource bundle manifest.
+    The {{{./remote-resources.html}manifest file}},
+    <<<$\{basedir\}/target/classes/META-INF/maven/remote-resources.xml>>>, comes from
+    <<<src/main/resources>>>.
 
-  * {{{./process-mojo.html}remote-resources:process}} retrieves the specified
-    remote resource bundles, processes them and makes them available to the
-    <<<process-resources>>> phase.
+  * {{{./process-mojo.html}remote-resources:process}} retrieves remote resource bundles,
+    processes them, and makes them available to the process-resources phase.
 
-  * {{{./aggregate-mojo.html}remote-resources:aggregate}} retrieves the specified
-    remote resource bundles, processes them and makes them available to the
-    <<<process-resources>>> phase in aggregate mode.
+  * {{{./aggregate-mojo.html}remote-resources:aggregate}} retrieves remote resource bundles,
+    processes them in aggregate mode, and makes them available to the process-resources phase.
 
   []
 
 * Usage
 
-  General instructions on how to use the Remote Resources Plugin can be found on the {{{./usage.html}usage page}}.
-  Some more specific use cases are described in the examples given below.
-  
-  If you need help using some of the more advanced features of the plugin, check out the advanced help pages:
-   
+  General instructions for using the Remote Resources Plugin are on the {{{./usage.html}usage page}}.
+  Some specific use cases appear in the examples below.
+
+  If you need help with advanced features, see the advanced help pages:
+
   * {{{./supplemental-models.html}Patching Bad POMs with Supplemental Models}}
-  
+
   []
 
-  In case you still have questions regarding the plugin's usage, please have a look at the {{{./faq.html}FAQ}} and feel
-  free to contact the {{{./mailing-lists.html}user mailing list}}. The posts to the mailing list are archived and could
-  already contain the answer to your question as part of an older thread. Hence, it is also worth browsing/searching
-  the {{{./mailing-lists.html}mail archive}}.
+  If you have questions about the plugin, check the {{{./faq.html}FAQ}} or contact the
+  {{{./mailing-lists.html}user mailing list}}. Posts to the mailing list are archived.
+  You can browse or search the {{{./mailing-lists.html}mail archive}}.
 
-  If you feel like the plugin is missing a feature or has a defect, you can fill a feature request or bug report in our
-  {{{./issue-management.html}issue tracker}}. When creating a new issue, please provide a comprehensive description of your
-  concern. Especially for fixing bugs it is crucial that the developers can reproduce your problem. For this reason,
-  entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.
-  Of course, patches are welcome, too. Contributors can check out the project from our
-  {{{./scm.html}source repository}} and will find supplementary information in the
+  If you think the plugin is missing a feature or has a defect, file a feature request or bug report.
+  When creating an issue, provide a clear description of your concern.
+  For fixing bugs, attach entire debug logs, POMs, or demo projects.
+  We also welcome patches. Contributors can get code from our
+  {{{./scm.html}source repository}} and find more information in the
   {{{/guides/development/guide-helping.html}guide to helping with Maven}}.
 
 * Examples
 
-  To provide you with better understanding of some usages of the Remote Resources Plugin,
-  you can take a look at the following examples:
+  To help you understand the Remote Resources Plugin usages,
+  see these examples:
 
   * {{{./examples/sharing-resources.html}Sharing Resources Example}}

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -9,10 +9,10 @@
 ~~ Licensed to the Apache Software Foundation (ASF) under one
 ~~ or more contributor license agreements.  See the NOTICE file
 ~~ distributed with this work for additional information
-~~ regarding copyright ownership. The ASF licenses this file
+~~ regarding copyright ownership.  The ASF licenses this file
 ~~ to you under the Apache License, Version 2.0 (the
 ~~ "License"); you may not use this file except in compliance
-~~ with the License. You may obtain a copy of the License at
+~~ with the License.  You may obtain a copy of the License at
 ~~
 ~~   http://www.apache.org/licenses/LICENSE-2.0
 ~~

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -19,7 +19,7 @@
 ~~ Unless required by applicable law or agreed to in writing,
 ~~ software distributed under the License is distributed on an
 ~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-~~ KIND, either express or implied. See the License for the
+~~ KIND, either express or implied.  See the License for the
 ~~ specific language governing permissions and limitations
 ~~ under the License.
 

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -4,17 +4,17 @@
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
+regarding copyright ownership. The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
+with the License. You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
+KIND, either express or implied. See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
@@ -27,29 +27,25 @@ under the License.
       <question>Why do I need to use this plugin?</question>
       <answer>
         <p>
-          This plugin greatly reduces the pain associated with consistent packaging concerns across
-          a large set of projects, or an entire organization. Any project can specify the use of a
-          remote resource bundle and have the resources incorporated into their packaging. This means
-          that you can create standard settings in a parent POM somewhere in the project hierarchy and
-          have all projects use packaged common resources in a standard way like licenses, other legal
-          notices and disclaimers, or anything else that may be common.
+          This plugin reduces the pain of consistent packaging across many projects.
+          Any project can specify a remote resource bundle.
+          The resources get incorporated into their packaging.
+          You can create standard settings in a parent POM and have all projects use packaged common resources.
         </p>
       </answer>
     </faq>
     <faq id="question2">
-      <question>The generated files have a lot of missing information.  Looking at the POMs from
-        the dependencies, the information isn't there either.  What can I do?</question>
+      <question>The generated files have missing information. The POMs from dependencies do not contain this information. What should I do?</question>
       <answer>
         <p>
-          There are two solutions:
+          You can do one of these two things:
         </p>
         <ol>
           <li>
             File bugs with the projects that produced those artifacts to get them to fix them.
           </li>
           <li>
-            Use a supplemental data file.  You can create a file that contains the missing metadata.
-            For example:
+            Use a supplemental data file. For example:
             <source><![CDATA[
               <supplementalDataModels>
                 <supplement>
@@ -71,9 +67,8 @@ under the License.
                 </supplement>
               </supplementalDataModels>]]>
             </source>
-            That location of that file can then be configured with the
-            <code>supplementalModels</code> configuration element for the <code>process</code> goal.  The
-            supplemental information is merged with the information provided from the repository.
+            You configure the supplementalModels configuration element for the process goal with that location.
+            The supplemental information merges with the repository data.
           </li>
         </ol>
       </answer>

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -4,17 +4,17 @@
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
-regarding copyright ownership. The ASF licenses this file
+regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at
+with the License.  You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied. See the License for the
+KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

--- a/src/site/xdoc/download.xml.vm
+++ b/src/site/xdoc/download.xml.vm
@@ -4,17 +4,17 @@
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
+regarding copyright ownership. The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
+with the License. You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
+KIND, either express or implied. See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
@@ -27,17 +27,17 @@ under the License.
   <body>
     <section name="Download ${project.name} ${project.version} Source">
 
-      <p><strong>${project.name} ${project.version}</strong> is distributed in source format.</p>
+      <p><strong>${project.name} ${project.version}</strong> distributes source code.</p>
 
-      <p>Use a source archive if you intend to build <strong>${project.name}</strong> yourself.</p>
+      <p>Use a source archive if you want to build ${project.name} yourself.</p>
 
-      <p>Otherwise, simply use the ready-made binary artifacts from <strong>central repository</strong>.</p>
+      <p>Otherwise, use the ready-made binary artifacts from the central repository.</p>
 
-      <p><strong>${project.name}</strong> is distributed under the <a href="https://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
+      <p><strong>${project.name}</strong> uses the Apache License, version 2.0.</p>
 
       <subsection name="Files">
-        
-        <p>This is the current stable version of <strong>${project.name}</strong>.</p>
+
+        <p>This is the current stable version of ${project.name}.</p>
 
         <table>
           <thead>
@@ -58,18 +58,15 @@ under the License.
           </tbody>
         </table>
 
-        <p>It is essential that you <a href="https://www.apache.org/info/verification.html">verify the integrity</a> of the downloaded file
-          using the checksum (.sha512 file)
-          or using the signature (.asc file) against the public <a href="https://downloads.apache.org/maven/KEYS">KEYS</a> used by the Apache Maven developers.
-        </p>
+        <p>You must verify the integrity of the downloaded file using the checksum (.sha512 file) or using the signature (.asc file).</p>
+        <p>Use the public KEYS that Apache Maven developers provide to verify.</p>
 
       </subsection>
 
       <subsection name="Previous Versions">
-        <p>It is strongly recommended to use the latest release version of <strong>${project.name}</strong> to take advantage of the newest features and bug fixes.</p>
-        <p>Older non-recommended releases can be found on our <a href="https://archive.apache.org/dist/maven/plugins/">archive site</a>.</p>
+        <p>You must use the latest release version of ${project.name} to get new features and bug fixes.</p>
+        <p>Older releases exist on the archive site. These releases are not recommended.</p>
       </subsection>
     </section>
   </body>
 </document>
-

--- a/src/site/xdoc/download.xml.vm
+++ b/src/site/xdoc/download.xml.vm
@@ -4,17 +4,17 @@
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
-regarding copyright ownership. The ASF licenses this file
+regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at
+with the License.  You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied. See the License for the
+KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->


### PR DESCRIPTION
This PR rewrites the maven-remote-resources-plugin download.xml.vm, index.apt.vm and faq.fml documentation to comply with ASD-STE100 Simplified Technical English rules. Changes include: removing banned words (simply, strongly), removing 'it is' constructions, using only approved modals (must, can, will), splitting long sentences (max 25 words), and using simple tenses.