### PR TITLE
Update javadoc of velocityFilterInMemoryThreshold (#276)

### DIFF
--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -250,7 +250,7 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
     protected boolean includeProjectProperties = false;
 
     /**
-     * This parameter is not used, it is kept for backward compatibility only.
+     * This parameter is not used. It is kept for backward compatibility only.
      *
      * @deprecated not used anymore
      * @since 1.6

--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -250,9 +250,7 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
     protected boolean includeProjectProperties = false;
 
     /**
-     * When the result of velocity transformation fits in memory, it is compared with the actual contents on disk
-     * to eliminate unnecessary destination file overwrite. This improves build times since further build steps
-     * typically rely on the modification date.
+     * This parameter is not used, it is kept for backward compatibility only.
      *
      * @deprecated not used anymore
      * @since 1.6


### PR DESCRIPTION
Closes #276

Replaces the outdated javadoc description of the `velocityFilterInMemoryThreshold` parameter with a note stating that it is not used and is kept for backward compatibility only. The parameter itself is unchanged.