### PR TITLE
Fail with MojoExecutionException on malformed supplemental model (#266)

### DIFF
--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -1080,6 +1080,10 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
             Xpp3Dom dom = (Xpp3Dom) sd.getProject();
 
             Model m = getSupplement(dom);
+            if (m == null) {
+                getLog().warn("Skipping malformed supplemental model entry.");
+                continue;
+            }
             supplementMap.put(generateSupplementMapKey(m.getGroupId(), m.getArtifactId()), m);
         }
 

--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -1007,7 +1007,7 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
 
     protected Model getSupplement(Xpp3Dom supplementModelXml) throws MojoExecutionException {
         MavenXpp3Reader modelReader = new MavenXpp3Reader();
-        Model model = null;
+        Model model;
 
         try {
             model = modelReader.read(new StringReader(supplementModelXml.toString()));
@@ -1024,9 +1024,9 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
                         "Supplemental project XML " + "requires that a <artifactId> element be present.");
             }
         } catch (IOException e) {
-            getLog().warn("Unable to read supplemental XML: " + e.getMessage(), e);
+            throw new MojoExecutionException("Unable to read supplemental XML: " + e.getMessage(), e);
         } catch (XmlPullParserException e) {
-            getLog().warn("Unable to parse supplemental XML: " + e.getMessage(), e);
+            throw new MojoExecutionException("Unable to parse supplemental XML: " + e.getMessage(), e);
         }
 
         return model;
@@ -1080,10 +1080,6 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
             Xpp3Dom dom = (Xpp3Dom) sd.getProject();
 
             Model m = getSupplement(dom);
-            if (m == null) {
-                getLog().warn("Skipping malformed supplemental model entry.");
-                continue;
-            }
             supplementMap.put(generateSupplementMapKey(m.getGroupId(), m.getArtifactId()), m);
         }
 

--- a/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
@@ -91,6 +91,31 @@ public class RemoteResourcesMojoTest extends AbstractMojoTestCase {
         mojo.execute();
     }
 
+    public void testMalformedSupplementalModelDoesNotBreakBuild() throws Exception {
+        final MavenProjectResourcesStub project = createTestProject("default-malformedsupplement");
+        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithDefaultSettings(project);
+
+        setupDefaultProject(project);
+
+        File supplementalModelsFile = new File(project.getBasedir(), "supplemental-models.xml");
+        FileUtils.fileWrite(
+                supplementalModelsFile.getAbsolutePath(),
+                "<supplementalDataModels>"
+                        + "<supplement>"
+                        + "<project>"
+                        + "<groupId>test</groupId>"
+                        + "<artifactId>test</artifactId>"
+                        + "<version>1.0</version>"
+                        + "<notAValidElement>whatever</notAValidElement>"
+                        + "</project>"
+                        + "</supplement>"
+                        + "</supplementalDataModels>");
+
+        setVariableValueToObject(mojo, "supplementalModels", new String[] {supplementalModelsFile.getAbsolutePath()});
+
+        mojo.execute();
+    }
+
     public void testCreateBundle() throws Exception {
         List<String> resources =
                 Arrays.asList("FILTER.txt.vm", "ISO-8859-1.bin.vm", "PROPERTIES.txt.vm", "SIMPLE.txt", "UTF-8.bin.vm");

--- a/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
@@ -41,6 +41,7 @@ import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.DefaultMavenExecutionResult;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.resources.remote.stub.MavenProjectBuildStub;
 import org.apache.maven.plugin.resources.remote.stub.MavenProjectResourcesStub;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
@@ -91,7 +92,7 @@ public class RemoteResourcesMojoTest extends AbstractMojoTestCase {
         mojo.execute();
     }
 
-    public void testMalformedSupplementalModelDoesNotBreakBuild() throws Exception {
+    public void testMalformedSupplementalModelFailsWithMojoExecutionException() throws Exception {
         final MavenProjectResourcesStub project = createTestProject("default-malformedsupplement");
         final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithDefaultSettings(project);
 
@@ -113,7 +114,12 @@ public class RemoteResourcesMojoTest extends AbstractMojoTestCase {
 
         setVariableValueToObject(mojo, "supplementalModels", new String[] {supplementalModelsFile.getAbsolutePath()});
 
-        mojo.execute();
+        try {
+            mojo.execute();
+            fail("Expected a MojoExecutionException for a malformed supplemental model entry");
+        } catch (MojoExecutionException e) {
+            assertTrue(e.getMessage(), e.getMessage().contains("Unable to parse supplemental XML"));
+        }
     }
 
     public void testCreateBundle() throws Exception {


### PR DESCRIPTION
Closes #266

## Test-first
Added `RemoteResourcesMojoTest.testMalformedSupplementalModelFailsWithMojoExecutionException()`, which configures a `supplemental-models.xml` containing a well-formed `<project>` element that the strict `MavenXpp3Reader` rejects (an unrecognized element).

The test asserts that executing the mojo fails with a `MojoExecutionException` whose message contains "Unable to parse supplemental XML".

Before the fix this test fails with:
```
java.lang.NullPointerException: Cannot invoke "org.apache.maven.model.Model.getGroupId()" because "m" is null
```

## Fix
`getSupplement()` now throws a `MojoExecutionException` (with the parse cause) instead of logging a warning and returning `null`, so a malformed supplemental model entry fails the build cleanly rather than crashing with an NPE in `loadSupplements()`.

## Verification
- New test fails before the fix (NPE), passes after.
- Full suite: `mvn verify` passes (11 unit tests, RAT).