### PR TITLE
Close the remote resources classloader after execution (#273)

### DIFF
--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -369,6 +369,8 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
 
     private VelocityEngine velocity;
 
+    private RemoteResourcesClassLoader classLoader;
+
     protected final RepositorySystem repoSystem;
 
     /**
@@ -435,7 +437,7 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
             List<File> resourceBundleArtifacts = downloadBundles(resourceBundles);
             supplementModels = loadSupplements(supplementalModels);
 
-            ClassLoader classLoader = initalizeClassloader(resourceBundleArtifacts);
+            classLoader = initalizeClassloader(resourceBundleArtifacts);
 
             Thread.currentThread().setContextClassLoader(classLoader);
 
@@ -476,6 +478,13 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
             }
         } finally {
             Thread.currentThread().setContextClassLoader(origLoader);
+            if (classLoader != null) {
+                try {
+                    classLoader.close();
+                } catch (IOException e) {
+                    getLog().debug("Error closing remote resources classloader: " + e.getMessage(), e);
+                }
+            }
         }
     }
 
@@ -862,7 +871,7 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
         return bundleArtifacts;
     }
 
-    private ClassLoader initalizeClassloader(List<File> artifacts) throws MojoExecutionException {
+    private RemoteResourcesClassLoader initalizeClassloader(List<File> artifacts) throws MojoExecutionException {
         RemoteResourcesClassLoader cl = new RemoteResourcesClassLoader(null);
         try {
             for (File artifact : artifacts) {

--- a/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
@@ -165,6 +165,28 @@ public class RemoteResourcesMojoTest extends AbstractMojoTestCase {
         assertTrue(file.exists());
     }
 
+    public void testClassLoaderIsClosedAfterExecution() throws Exception {
+        final MavenProjectResourcesStub project = createTestProject("default-closeclassloader");
+        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings(project, new String[] {"test:test:1.0"});
+
+        setupDefaultProject(project);
+
+        String path = pathOf(new DefaultArtifact(
+                "test", "test", VersionRange.createFromVersion("1.0"), null, "jar", "", new DefaultArtifactHandler()));
+
+        File file = new File(path);
+        file.getParentFile().mkdirs();
+        buildResourceBundle("default-closeclassloader-create", null, new String[] {"SIMPLE.txt"}, file);
+
+        mojo.execute();
+
+        RemoteResourcesClassLoader classLoader =
+                (RemoteResourcesClassLoader) getVariableValueFromObject(mojo, "classLoader");
+        assertNotNull(classLoader);
+        // resources from the bundle jars must no longer be served by the closed classloader
+        assertNull(classLoader.getResource("SIMPLE.txt"));
+    }
+
     public void testVelocityUTF8() throws Exception {
         final MavenProjectResourcesStub project = createTestProject("default-utf8");
         final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings(project, new String[] {"test:test:1.2"});


### PR DESCRIPTION
Closes #273

## Test-first
Added `RemoteResourcesMojoTest.testClassLoaderIsClosedAfterExecution()`, which executes the mojo against a bundle and then asserts that the plugin's `RemoteResourcesClassLoader` no longer serves resources from the bundle jars (i.e. it has been closed).

Before the fix the mojo never even kept a reference to close, so the test fails.

## Fix
`AbstractProcessRemoteResourcesMojo` now stores the `RemoteResourcesClassLoader` it creates and closes it in the `finally` block of `execute()` (after restoring the original context classloader), releasing the bundle jar file handles instead of leaking them per execution. The `initalizeClassloader` return type was narrowed to `RemoteResourcesClassLoader` to match.

## Verification
- New test fails before the fix, passes after.
- `mvn verify` passes (11 unit tests, RAT, checkstyle).
- `mvn spotless:apply` reports no formatting changes.