### PR TITLE
Render project .vm overrides with Velocity when useProjectFiles is set (#267)

### DIFF
--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -663,15 +663,34 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
         return false;
     }
 
-    private boolean copyProjectRootIfExists(File outputFile, String bundleResourceName) throws IOException {
+    private boolean copyProjectRootIfExists(
+            File outputFile, String bundleResourceName, VelocityContext context, String encoding)
+            throws IOException, MojoExecutionException {
         if (!useProjectFiles) {
             return false;
         }
 
         File source = new File(project.getBasedir(), bundleResourceName);
+        File templateSource = new File(project.getBasedir(), bundleResourceName + TEMPLATE_SUFFIX);
+
+        if (!source.exists() && templateSource.exists()) {
+            source = templateSource;
+        }
+
         if (source.exists()) {
-            getLog().debug("Use project file '" + source + "' as resource");
-            FilteringUtils.copyFile(source, outputFile, null, null);
+            if (source == templateSource) {
+                getLog().debug("Use project file '" + source + "' as resource with Velocity");
+                try (CachingOutputStream os = new CachingOutputStream(outputFile);
+                        Writer writer = getWriter(encoding, os);
+                        Reader reader = getReader(encoding, source)) {
+                    velocity.evaluate(context, writer, "", reader);
+                } catch (ParseErrorException | MethodInvocationException | ResourceNotFoundException e) {
+                    throw new MojoExecutionException("Error rendering velocity resource: " + source, e);
+                }
+            } else {
+                getLog().debug("Use project file '" + source + "' as resource");
+                FilteringUtils.copyFile(source, outputFile, null, null);
+            }
             return true;
         }
 
@@ -942,7 +961,7 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
                     continue;
                 }
 
-                if (copyProjectRootIfExists(outputFile, projectResource)) {
+                if (copyProjectRootIfExists(outputFile, projectResource, context, bundle.getSourceEncoding())) {
                     continue;
                 }
 

--- a/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
@@ -165,6 +165,31 @@ public class RemoteResourcesMojoTest extends AbstractMojoTestCase {
         assertTrue(file.exists());
     }
 
+    public void testUseProjectFilesRendersVelocityTemplate() throws Exception {
+        final MavenProjectResourcesStub project = createTestProject("default-useprojectfiles");
+        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings(project, new String[] {"test:test:1.4"});
+
+        setupDefaultProject(project);
+
+        FileUtils.fileWrite(
+                new File(project.getBasedir(), "FILTER.txt.vm").getAbsolutePath(), "local override: $project.name");
+
+        String path = pathOf(new DefaultArtifact(
+                "test", "test", VersionRange.createFromVersion("1.4"), null, "jar", "", new DefaultArtifactHandler()));
+
+        File file = new File(path);
+        file.getParentFile().mkdirs();
+        buildResourceBundle("default-useprojectfiles-create", null, new String[] {"FILTER.txt.vm"}, file);
+
+        setVariableValueToObject(mojo, "useProjectFiles", true);
+
+        mojo.execute();
+
+        File outputFile = new File((File) getVariableValueFromObject(mojo, "outputDirectory"), "FILTER.txt");
+        String data = FileUtils.fileRead(outputFile);
+        assertTrue(data.contains("local override: Test Project default-useprojectfiles"));
+    }
+
     public void testVelocityUTF8() throws Exception {
         final MavenProjectResourcesStub project = createTestProject("default-utf8");
         final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings(project, new String[] {"test:test:1.2"});


### PR DESCRIPTION
Fixes https://github.com/apache/maven-remote-resources-plugin/issues/267

### Problem

When `useProjectFiles` is enabled, a resource override placed in the project
root is copied verbatim via `FilteringUtils.copyFile`, bypassing Velocity
processing. Unlike `copyResourceIfExists`, `copyProjectRootIfExists` also only
looked for `<name>`, never for the `<name>.vm` template variant, so `.vm`
overrides were silently ignored and the bundle template was used instead.

### Changes

- `copyProjectRootIfExists` now mirrors `copyResourceIfExists`:
  - checks for both `<name>` and `<name>.vm` in the project root
  - renders `<name>.vm` through Velocity (`velocity.evaluate`) with the bundle's
    source encoding, matching the behavior of bundle-resource templates
  - plain files are still copied verbatim

### Tests

- New test `testUseProjectFilesRendersVelocityTemplate`: writes a local
  `<basedir>/FILTER.txt.vm` containing `$project.name`, sets `useProjectFiles`
  and asserts the output `FILTER.txt` contains the rendered project name.
- Verified the test fails without the fix and passes with it; full `mvn verify`
  (incl. spotless/checkstyle/RAT) passes.