### PR TITLE
Fix getProjects() mutating project artifact versions (#268)

### DIFF
--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -663,15 +663,34 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
         return false;
     }
 
-    private boolean copyProjectRootIfExists(File outputFile, String bundleResourceName) throws IOException {
+    private boolean copyProjectRootIfExists(
+            File outputFile, String bundleResourceName, VelocityContext context, String encoding)
+            throws IOException, MojoExecutionException {
         if (!useProjectFiles) {
             return false;
         }
 
         File source = new File(project.getBasedir(), bundleResourceName);
+        File templateSource = new File(project.getBasedir(), bundleResourceName + TEMPLATE_SUFFIX);
+
+        if (!source.exists() && templateSource.exists()) {
+            source = templateSource;
+        }
+
         if (source.exists()) {
-            getLog().debug("Use project file '" + source + "' as resource");
-            FilteringUtils.copyFile(source, outputFile, null, null);
+            if (source == templateSource) {
+                getLog().debug("Use project file '" + source + "' as resource with Velocity");
+                try (CachingOutputStream os = new CachingOutputStream(outputFile);
+                        Writer writer = getWriter(encoding, os);
+                        Reader reader = getReader(encoding, source)) {
+                    velocity.evaluate(context, writer, "", reader);
+                } catch (ParseErrorException | MethodInvocationException | ResourceNotFoundException e) {
+                    throw new MojoExecutionException("Error rendering velocity resource: " + source, e);
+                }
+            } else {
+                getLog().debug("Use project file '" + source + "' as resource");
+                FilteringUtils.copyFile(source, outputFile, null, null);
+            }
             return true;
         }
 
@@ -942,7 +961,7 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
                     continue;
                 }
 
-                if (copyProjectRootIfExists(outputFile, projectResource)) {
+                if (copyProjectRootIfExists(outputFile, projectResource, context, bundle.getSourceEncoding())) {
                     continue;
                 }
 

--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -532,7 +532,20 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
 
         for (Artifact artifact : artifacts) {
             if (artifact.isSnapshot()) {
-                artifact.setVersion(artifact.getBaseVersion());
+                // build a new artifact from the base version instead of mutating the shared
+                // artifact instances (e.g. the ones from project.getArtifacts())
+                org.apache.maven.artifact.DefaultArtifact snapshotArtifact =
+                        new org.apache.maven.artifact.DefaultArtifact(
+                                artifact.getGroupId(),
+                                artifact.getArtifactId(),
+                                artifact.getBaseVersion(),
+                                artifact.getScope(),
+                                artifact.getType(),
+                                artifact.getClassifier(),
+                                artifact.getArtifactHandler());
+                snapshotArtifact.setFile(artifact.getFile());
+                snapshotArtifact.setResolved(artifact.isResolved());
+                artifact = snapshotArtifact;
             }
 
             getLog().debug("Building project for " + artifact);

--- a/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
@@ -165,6 +165,31 @@ public class RemoteResourcesMojoTest extends AbstractMojoTestCase {
         assertTrue(file.exists());
     }
 
+    public void testUseProjectFilesRendersVelocityTemplate() throws Exception {
+        final MavenProjectResourcesStub project = createTestProject("default-useprojectfiles");
+        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings(project, new String[] {"test:test:1.4"});
+
+        setupDefaultProject(project);
+
+        FileUtils.fileWrite(
+                new File(project.getBasedir(), "FILTER.txt.vm").getAbsolutePath(), "local override: $project.name");
+
+        String path = pathOf(new DefaultArtifact(
+                "test", "test", VersionRange.createFromVersion("1.4"), null, "jar", "", new DefaultArtifactHandler()));
+
+        File file = new File(path);
+        file.getParentFile().mkdirs();
+        buildResourceBundle("default-useprojectfiles-create", null, new String[] {"FILTER.txt.vm"}, file);
+
+        setVariableValueToObject(mojo, "useProjectFiles", true);
+
+        mojo.execute();
+
+        File outputFile = new File((File) getVariableValueFromObject(mojo, "outputDirectory"), "FILTER.txt");
+        String data = FileUtils.fileRead(outputFile);
+        assertTrue(data.contains("local override: Test Project default-useprojectfiles"));
+    }
+
     public void testVelocityUTF8() throws Exception {
         final MavenProjectResourcesStub project = createTestProject("default-utf8");
         final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithSettings(project, new String[] {"test:test:1.2"});

--- a/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
@@ -41,6 +42,7 @@ import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.DefaultMavenExecutionResult;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.resources.remote.stub.ArtifactStub;
 import org.apache.maven.plugin.resources.remote.stub.MavenProjectBuildStub;
 import org.apache.maven.plugin.resources.remote.stub.MavenProjectResourcesStub;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
@@ -188,6 +190,27 @@ public class RemoteResourcesMojoTest extends AbstractMojoTestCase {
         File outputFile = new File((File) getVariableValueFromObject(mojo, "outputDirectory"), "FILTER.txt");
         String data = FileUtils.fileRead(outputFile);
         assertTrue(data.contains("local override: Test Project default-useprojectfiles"));
+    }
+
+    public void testProjectsDoesNotMutateProjectArtifactVersions() throws Exception {
+        final MavenProjectResourcesStub project = createTestProject("default-nomutate");
+        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithDefaultSettings(project);
+
+        setupDefaultProject(project);
+
+        setVariableValueToObject(mojo, "supplementModels", new HashMap<>());
+
+        ArtifactStub snapshotArtifact = new ArtifactStub();
+        snapshotArtifact.setGroupId("org.example");
+        snapshotArtifact.setArtifactId("snapshot-dep");
+        snapshotArtifact.setVersion("1.0-SNAPSHOT");
+
+        project.setArtifacts(Collections.singleton(snapshotArtifact));
+
+        mojo.getProjects();
+
+        assertEquals("1.0-SNAPSHOT", snapshotArtifact.getVersion());
+        assertSame(snapshotArtifact, project.getArtifacts().iterator().next());
     }
 
     public void testVelocityUTF8() throws Exception {


### PR DESCRIPTION
Fixes https://github.com/apache/maven-remote-resources-plugin/issues/268

### Problem

`getProjects()` called `artifact.setVersion(artifact.getBaseVersion())` on the
artifact instances obtained from `getAllDependencies()`. For the `process`
mojo, `getAllDependencies()` returns `project.getArtifacts()` directly, so this
mutated the live, shared `Artifact` objects — stripping timestamped snapshot
versions down to their base version as a side effect that later build steps
observe. The mutation only happened when a template referenced
`$projects`/`$projectsSortedByOrganization`.

### Fix

Instead of mutating the shared instance, build a new `DefaultArtifact` from the
artifact's base version (carrying over file, resolution state and the other
coordinates) and use that only for the project model building. The original
artifacts in `project.getArtifacts()` are left untouched.

### Test

New unit test `testProjectsDoesNotMutateProjectArtifactVersions`: adds a
snapshot artifact to the project, invokes `getProjects()`, and asserts the
artifact's version is still `1.0-SNAPSHOT` (and that the same instance remains
in `project.getArtifacts()`). Verified the test fails without the fix
(`expected:<[1.0-SNAPSHOT]> but was:<[Test Version]>`) and passes with it.
Full `mvn verify` (incl. spotless/checkstyle/RAT) passes.