### PR TITLE
Fix getProjects() mutating project artifact versions (#268)

### DIFF
--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -532,7 +532,20 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
 
         for (Artifact artifact : artifacts) {
             if (artifact.isSnapshot()) {
-                artifact.setVersion(artifact.getBaseVersion());
+                // build a new artifact from the base version instead of mutating the shared
+                // artifact instances (e.g. the ones from project.getArtifacts())
+                org.apache.maven.artifact.DefaultArtifact snapshotArtifact =
+                        new org.apache.maven.artifact.DefaultArtifact(
+                                artifact.getGroupId(),
+                                artifact.getArtifactId(),
+                                artifact.getBaseVersion(),
+                                artifact.getScope(),
+                                artifact.getType(),
+                                artifact.getClassifier(),
+                                artifact.getArtifactHandler());
+                snapshotArtifact.setFile(artifact.getFile());
+                snapshotArtifact.setResolved(artifact.isResolved());
+                artifact = snapshotArtifact;
             }
 
             getLog().debug("Building project for " + artifact);

--- a/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
@@ -41,6 +42,7 @@ import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.DefaultMavenExecutionResult;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.resources.remote.stub.ArtifactStub;
 import org.apache.maven.plugin.resources.remote.stub.MavenProjectBuildStub;
 import org.apache.maven.plugin.resources.remote.stub.MavenProjectResourcesStub;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
@@ -163,6 +165,27 @@ public class RemoteResourcesMojoTest extends AbstractMojoTestCase {
         file = (File) getVariableValueFromObject(mojo, "outputDirectory");
         file = new File(file, "SIMPLE.txt");
         assertTrue(file.exists());
+    }
+
+    public void testProjectsDoesNotMutateProjectArtifactVersions() throws Exception {
+        final MavenProjectResourcesStub project = createTestProject("default-nomutate");
+        final ProcessRemoteResourcesMojo mojo = lookupProcessMojoWithDefaultSettings(project);
+
+        setupDefaultProject(project);
+
+        setVariableValueToObject(mojo, "supplementModels", new HashMap<>());
+
+        ArtifactStub snapshotArtifact = new ArtifactStub();
+        snapshotArtifact.setGroupId("org.example");
+        snapshotArtifact.setArtifactId("snapshot-dep");
+        snapshotArtifact.setVersion("1.0-SNAPSHOT");
+
+        project.setArtifacts(Collections.singleton(snapshotArtifact));
+
+        mojo.getProjects();
+
+        assertEquals("1.0-SNAPSHOT", snapshotArtifact.getVersion());
+        assertSame(snapshotArtifact, project.getArtifacts().iterator().next());
     }
 
     public void testVelocityUTF8() throws Exception {


### PR DESCRIPTION
Fixes https://github.com/apache/maven-remote-resources-plugin/issues/268

### Problem

`getProjects()` called `artifact.setVersion(artifact.getBaseVersion())` on the
artifact instances obtained from `getAllDependencies()`. For the `process`
mojo, `getAllDependencies()` returns `project.getArtifacts()` directly, so this
mutated the live, shared `Artifact` objects — stripping timestamped snapshot
versions down to their base version as a side effect that later build steps
observe. The mutation only happened when a template referenced
`$projects`/`$projectsSortedByOrganization`.

### Fix

Instead of mutating the shared instance, build a new `DefaultArtifact` from the
artifact's base version (carrying over file, resolution state and the other
coordinates) and use that only for the project model building. The original
artifacts in `project.getArtifacts()` are left untouched.

### Test

New unit test `testProjectsDoesNotMutateProjectArtifactVersions`: adds a
snapshot artifact to the project, invokes `getProjects()`, and asserts the
artifact's version is still `1.0-SNAPSHOT` (and that the same instance remains
in `project.getArtifacts()`). Verified the test fails without the fix
(`expected:<[1.0-SNAPSHOT]> but was:<[Test Version]>`) and passes with it.
Full `mvn verify` (incl. spotless/checkstyle/RAT) passes.