### PR TITLE
Perf: hoist orderAfterMerge out of the parent-plugin loop (#271)

### DIFF
--- a/src/main/java/org/apache/maven/plugin/resources/remote/ModelUtils.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/ModelUtils.java
@@ -105,16 +105,18 @@ public final class ModelUtils {
                         parentPlugin.unsetInheritanceApplied();
                     }
                 }
-
-                // very important to use the parentPlugins List, rather than parentContainer.getPlugins()
-                // since this list is a local one, and may have been modified during processing.
-                List<Plugin> results =
-                        ModelUtils.orderAfterMerge(assembledPlugins, parentPlugins, childContainer.getPlugins());
-
-                childContainer.setPlugins(results);
-
-                childContainer.flushPluginMap();
             }
+
+            // very important to use the parentPlugins List, rather than parentContainer.getPlugins()
+            // since this list is a local one, and may have been modified during processing.
+            // The ordering only depends on the final assembled plugins, so compute it once after
+            // the loop instead of on every iteration.
+            List<Plugin> results =
+                    ModelUtils.orderAfterMerge(assembledPlugins, parentPlugins, childContainer.getPlugins());
+
+            childContainer.setPlugins(results);
+
+            childContainer.flushPluginMap();
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/apache/maven-remote-resources-plugin/issues/271

### Problem

`ModelUtils.mergePluginLists()` recomputed `ModelUtils.orderAfterMerge(...)` and
called `childContainer.setPlugins(results)` / `childContainer.flushPluginMap()`
on **every** iteration of the parent-plugin loop, even though the loop body
already accumulates the merged plugins into `assembledPlugins`.

`orderAfterMerge` walks both full plugin lists with `results.contains`/`indexOf`
linear scans, making the whole merge O(P³) in the worst case for P parent
plugins plus repeated plugin-map flushes. The ordering result is identical
whether computed once at the end or per-iteration.

### Fix

Hoist `orderAfterMerge(...)` + `setPlugins`/`flushPluginMap` out of the loop and
compute them once after the loop finishes, using the final `assembledPlugins`.

### Testing

No new tests (performance-only change). All existing tests pass, including the
failsafe integration tests run with `-Prun-its` (`ITSupplementalArtifact`
exercises the supplemental-model merge that uses `mergePluginLists`), plus
spotless/checkstyle/RAT via `mvn verify`.