### PR TITLE
Consistent resource-bundle descriptor validation (#272)

### DIFF
--- a/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugin/resources/remote/AbstractProcessRemoteResourcesMojo.java
@@ -723,9 +723,11 @@ public abstract class AbstractProcessRemoteResourcesMojo extends AbstractMojo {
         for (String artifactDescriptor : resourceBundles) {
             // groupId:artifactId:version, groupId:artifactId:version:type
             // or groupId:artifactId:version:type:classifier
-            String[] s = StringUtils.split(artifactDescriptor, ":");
+            // use the same splitting as downloadBundles() so both are consistent;
+            // also reject empty groupId/artifactId/version (e.g. a missing segment)
+            String[] s = artifactDescriptor.split(":");
 
-            if (s.length < 3 || s.length > 5) {
+            if (s.length < 3 || s.length > 5 || s[0].isEmpty() || s[1].isEmpty() || s[2].isEmpty()) {
                 String position;
 
                 if (bundleCount == 1) {

--- a/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/RemoteResourcesMojoTest.java
@@ -41,6 +41,7 @@ import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.DefaultMavenExecutionResult;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.resources.remote.stub.MavenProjectBuildStub;
 import org.apache.maven.plugin.resources.remote.stub.MavenProjectResourcesStub;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
@@ -277,6 +278,19 @@ public class RemoteResourcesMojoTest extends AbstractMojoTestCase {
         String data = FileUtils.fileRead(file);
         assertTrue(data.contains("maven"));
         assertTrue(data.contains("rules"));
+    }
+
+    public void testValidateRejectsDescriptorWithEmptySegment() throws Exception {
+        final MavenProjectResourcesStub project = createTestProject("default-validate");
+        final ProcessRemoteResourcesMojo mojo =
+                lookupProcessMojoWithSettings(project, new String[] {"org.example:dep::jar"});
+
+        try {
+            mojo.validate();
+            fail("Expected validate() to reject a resource bundle descriptor with a missing version");
+        } catch (MojoExecutionException e) {
+            assertTrue(e.getMessage().contains("resource bundle"));
+        }
     }
 
     protected void buildResourceBundle(String id, String sourceEncoding, String[] resourceNames, File jarName)


### PR DESCRIPTION
Fixes https://github.com/apache/maven-remote-resources-plugin/issues/272

### Problem

`validate()` split bundle descriptors with `StringUtils.split(artifactDescriptor, ":")`,
which collapses empty segments, while `downloadBundles()` used
`artifactDescriptor.split(":")`, which preserves them. So a malformed descriptor
such as `group:artifact::type` (missing version) passed `validate()` and then
failed later with a confusing resolution error, never showing the clear
validation message.

### Fix

`validate()` now uses the same `split(":")` logic as `downloadBundles()` and
additionally rejects descriptors where groupId, artifactId or version is empty
(e.g. a missing segment). Malformed descriptors now fail fast with the existing,
clear "resource bundle configured must specify..." message.

The reactor lookup in `downloadBundles()` compares with a non-null receiver
(`s[0].equals(p.getGroupId())`), so it is already null-safe.

### Test

New unit test `testValidateRejectsDescriptorWithEmptySegment`: configures a
`org.example:dep::jar` descriptor and asserts `validate()` throws the validation
error. Verified the test fails without the fix (`validate()` let the descriptor
through) and passes with it. Full `mvn verify -Prun-its` (unit + failsafe ITs,
spotless/checkstyle/RAT) passes.