### PR TITLE
Migrate legacy plugin Javadoc annotations

### DIFF
--- a/src/it/MRRESOURCES-121-dependencies-ignored/pom.xml
+++ b/src/it/MRRESOURCES-121-dependencies-ignored/pom.xml
@@ -48,6 +48,12 @@ under the License.
       <version>3.8.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>@version.maven-plugin-tools@</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/it/MRRESOURCES-121-dependencies-ignored/src/main/java/org/apache/maven/MyMojo.java
+++ b/src/it/MRRESOURCES-121-dependencies-ignored/src/main/java/org/apache/maven/MyMojo.java
@@ -18,6 +18,9 @@ package org.apache.maven;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -25,19 +28,15 @@ import java.io.IOException;
 
 /**
  * Goal which touches a timestamp file.
- *
- * @goal touch
- * 
- * @phase process-sources
  */
+@Mojo(name = "touch", defaultPhase = LifecyclePhase.PROCESS_SOURCES)
 public class MyMojo
     extends AbstractMojo
 {
     /**
      * Location of the file.
-     * @parameter expression="${project.build.directory}"
-     * @required
      */
+    @Parameter(defaultValue = "${project.build.directory}", required = true)
     private File outputDirectory;
 
     public void execute()

--- a/src/it/maven-remote-resources-test/pom.xml
+++ b/src/it/maven-remote-resources-test/pom.xml
@@ -38,6 +38,12 @@ under the License.
       <version>3.8.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>@version.maven-plugin-tools@</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/it/maven-remote-resources-test/src/main/java/org/apache/maven/MyMojo.java
+++ b/src/it/maven-remote-resources-test/src/main/java/org/apache/maven/MyMojo.java
@@ -18,6 +18,9 @@ package org.apache.maven;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -25,19 +28,15 @@ import java.io.IOException;
 
 /**
  * Goal which touches a timestamp file.
- *
- * @goal touch
- * 
- * @phase process-sources
  */
+@Mojo(name = "touch", defaultPhase = LifecyclePhase.PROCESS_SOURCES)
 public class MyMojo
     extends AbstractMojo
 {
     /**
      * Location of the file.
-     * @parameter expression="${project.build.directory}"
-     * @required
      */
+    @Parameter(defaultValue = "${project.build.directory}", required = true)
     private File outputDirectory;
 
     public void execute()


### PR DESCRIPTION
This updates the plugin sources in the `maven-remote-resources-test` and
`MRRESOURCES-121-dependencies-ignored` integration-test projects to use
`maven-plugin-annotations` instead of the legacy Maven Plugin Tools Javadoc
tags.

The conversion preserves each mojo's name, default lifecycle phase, and
parameter metadata. Both fixtures now declare `maven-plugin-annotations` with
`provided` scope and use the filtered `@version.maven-plugin-tools@` value so
they stay aligned with the Plugin Tools version used by the reactor.

This is part of removing reliance on the legacy QDox-backed Javadoc-tag
extractor discussed in https://github.com/apache/maven-plugin-tools/issues/718.
There is no runtime behavior change to the Remote Resources Plugin.

Validation on JDK 21:

- Maven 3.9.16: `mvn -B -V clean verify -Prun-its`
  - Invoker: 7 passed, 0 failed, 0 errors, 0 skipped
  - Failsafe: 9 tests passed, 0 failures, 0 errors, 0 skipped
- Maven 4.0.0-rc-6: `mvn -B -V clean verify -Prun-its`
  - Invoker: 7 passed, 0 failed, 0 errors, 0 skipped
  - Failsafe: 9 tests passed, 0 failures, 0 errors, 0 skipped

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice. This change updates existing integration-test fixtures and does not change runtime behavior.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
