### PR TITLE
Remove maven-compat without moving the consumer baseline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@ under the License.
     each project must include license and notice files for each release.</description>
 
   <prerequisites>
-    <maven>${mavenVersion}</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <scm>
@@ -65,9 +65,8 @@ under the License.
 
   <properties>
     <javaVersion>8</javaVersion>
-    <mavenVersion>3.6.3</mavenVersion>
-    <!-- the same version like in Maven 3.6.3 -->
-    <resolverVersion>1.4.1</resolverVersion>
+    <mavenVersion>3.9.16</mavenVersion>
+    <resolverVersion>1.9.27</resolverVersion>
     <project.build.outputTimestamp>2024-12-30T10:45:13Z</project.build.outputTimestamp>
 
     <!-- Used by site documentation as well, do not remove -->
@@ -232,13 +231,6 @@ under the License.
     </dependency>
     <dependency>
       <!-- needed in tests runtime -->
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <!-- needed in tests runtime -->
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>1.7.36</version>
@@ -371,7 +363,7 @@ under the License.
             </goals>
             <configuration>
               <failOnWarning>true</failOnWarning>
-              <ignoredDependencies>org.apache.maven:maven-compat:*,org.slf4j:slf4j-simple:*</ignoredDependencies>
+              <ignoredDependencies>org.slf4j:slf4j-simple:*</ignoredDependencies>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Nothing in the plugin imports anything from `maven-compat`. The declaration was commented "needed in tests runtime" — true, but not because of this plugin's code. Removing it alone does not work, and the reason is not in this plugin.

### Why it could not simply be deleted

`maven-core` **3.6.3** ships `DefaultProjectBuildingHelper` with a field of the legacy `org.apache.maven.repository.RepositorySystem`, whose only implementation — `LegacyRepositorySystem` — lives in maven-compat. So any test that looks up a Mojo needing `ProjectBuilder` fails without it, with zero compat code in the plugin:

```
No implementation for org.apache.maven.repository.RepositorySystem was bound.
  while locating org.apache.maven.project.DefaultProjectBuildingHelper
```

`maven-core` changed that field to `org.apache.maven.bridge.MavenRepositorySystem`, which lives in maven-core itself. Commit `3afbdb8f76` ("Use MavenRepositorySystem in ProjectBuildingHelper instead of deprecated RepositorySystem", #11358); `git tag --contains` gives `maven-3.9.12` as the first release carrying it. Confirmed against the bytecode:

```
maven-core 3.9.11   org.apache.maven.repository.RepositorySystem repositorySystem
maven-core 3.9.12   org.apache.maven.bridge.MavenRepositorySystem repositorySystem
```

### The consumer baseline does not move

`<prerequisites><maven>` now states a literal **3.6.3** instead of reading `${mavenVersion}`, so **the minimum Maven for consumers is unchanged**. That is how the rest of the 3.x plugin line already does it — maven-compiler-plugin, maven-deploy-plugin, maven-shade-plugin, maven-ear-plugin and others all state `3.6.3` there independently of what they build against.

Only the build-side versions move: `mavenVersion` to **3.9.16**, the current 3.9.x, and `resolverVersion` to the **1.9.27** that Maven 3.9.16 itself ships, rather than a version chosen independently. 3.9.12 is the earliest release where the compat dependency becomes unnecessary, but there is no reason to sit on that floor rather than the latest patch of the line.

The stale `<!-- the same version like in Maven 3.6.3 -->` comment above `resolverVersion` goes at the same time — it described the old pairing and would only mislead now.

One consequence worth stating plainly: building against 3.9.16 while declaring 3.6.3 gives up the compiler as a guard against accidentally using post-3.6.3 API. No plugin source changes here, so nothing in this PR can have introduced such a call, but it is the trade-off the rest of the line already accepts.

### Verification

`mvn verify`: **10 tests, 0 failures — identical to `master` under the same command.** Green on both sides, and `spotless:check` passes.

Ran `verify` rather than `test` deliberately: on a sibling plugin, removing maven-compat passed all tests while breaking the build, because a dependency was reaching the compile classpath through it and only the dependency analysis in `verify` catches that.

Part of a survey of which projects still declare `maven-compat` versus which genuinely need it. This one needed only the baseline.

The dependency-analysis `<ignoredDependencies>` entry for maven-compat goes at the same time.
