### PR TITLE
Migrate the AbstractIT-based integration test classes to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,7 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <!-- still required by AbstractMojoTestCase (deprecated, PlexusTestCase/JUnit 3 based); see RemoteResourcesMojoTest -->
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
@@ -215,6 +216,17 @@ under the License.
           <artifactId>hamcrest-core</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <!-- runs RemoteResourcesMojoTest (AbstractMojoTestCase/PlexusTestCase, JUnit 3 style) on the JUnit Platform -->
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
@@ -362,7 +374,13 @@ under the License.
             </goals>
             <configuration>
               <failOnWarning>true</failOnWarning>
-              <ignoredDependencies>org.slf4j:slf4j-simple:*</ignoredDependencies>
+              <ignoredDependencies>
+                <ignoredDependency>org.slf4j:slf4j-simple:*</ignoredDependency>
+                <!-- still needed at test runtime by the deprecated AbstractMojoTestCase/PlexusTestCase (JUnit 3) -->
+                <ignoredDependency>junit:junit:*</ignoredDependency>
+                <!-- JUnit Platform test engines, discovered via ServiceLoader, never referenced from bytecode -->
+                <ignoredDependency>org.junit.vintage:junit-vintage-engine:*</ignoredDependency>
+              </ignoredDependencies>
             </configuration>
           </execution>
         </executions>

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/AbstractIT.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/AbstractIT.java
@@ -19,10 +19,10 @@
 package org.apache.maven.plugin.resources.remote.it;
 
 import org.apache.maven.plugin.resources.remote.it.support.BootstrapInstaller;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class AbstractIT {
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         BootstrapInstaller.install();
     }

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/ITBadDependencyPoms.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/ITBadDependencyPoms.java
@@ -26,9 +26,9 @@ import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
 import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Benjamin Bentmann

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/ITCustomFilterDelimiter.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/ITCustomFilterDelimiter.java
@@ -26,9 +26,9 @@ import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
 import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ITCustomFilterDelimiter extends AbstractIT {
     @Test

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/ITFilterLocalOverride.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/ITFilterLocalOverride.java
@@ -26,9 +26,9 @@ import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
 import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ITFilterLocalOverride extends AbstractIT {
     @Test

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/ITGenerateFromBundle.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/ITGenerateFromBundle.java
@@ -26,9 +26,9 @@ import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
 import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ITGenerateFromBundle extends AbstractIT {
     @Test

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/ITGenerateFromBundleWithTypeAndClassifier.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/ITGenerateFromBundleWithTypeAndClassifier.java
@@ -26,9 +26,9 @@ import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
 import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ITGenerateFromBundleWithTypeAndClassifier extends AbstractIT {
     @Test

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/ITGenerateFromOverride.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/ITGenerateFromOverride.java
@@ -26,9 +26,9 @@ import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
 import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ITGenerateFromOverride extends AbstractIT {
     @Test

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/ITGetDependencyProjects.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/ITGetDependencyProjects.java
@@ -26,9 +26,9 @@ import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
 import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Benjamin Bentmann

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/ITRunOnlyAtExecutionRoot.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/ITRunOnlyAtExecutionRoot.java
@@ -27,11 +27,11 @@ import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.Os;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * @author Benjamin Bentmann

--- a/src/test/java/org/apache/maven/plugin/resources/remote/it/ITSupplementalArtifact.java
+++ b/src/test/java/org/apache/maven/plugin/resources/remote/it/ITSupplementalArtifact.java
@@ -26,9 +26,9 @@ import org.apache.maven.plugin.resources.remote.it.support.TestUtils;
 import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
 import org.codehaus.plexus.util.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author John Casey


### PR DESCRIPTION
Moves the 10 `AbstractIT`-derived test classes under `src/test/java/.../it/` (run by failsafe under the `run-its` profile) from JUnit 4 to Jupiter: `@Before` → `@BeforeEach`, `Assert.*` → `Assertions.*`, `Assume.assumeTrue` → `Assumptions.assumeTrue`. No assertion in this module passed a message, so there was no argument-order flip to get wrong.

`src/it/**` is untouched — that is a separate maven-invoker-plugin sample-project tree, not this suite.

**Deliberately not migrated: `RemoteResourcesMojoTest`.** It extends `AbstractMojoTestCase` → `PlexusTestCase` (JUnit 3 style, `testXxx()` methods). maven-plugin-testing-harness 3.5.1 does ship a JUnit 5 path (`@MojoTest`/`@InjectMojo`/`@MojoParameter`), so this is not a blocked dependency — but this test builds differently-configured mojo instances per test via `lookupMojo()` + `setVariableValueToObject()` with runtime-computed session and repository state, which does not map onto that declarative model without a real redesign. That is out of scope for a mechanical migration and wants its own change.

Because that class stays, `junit:junit` stays too, and `junit-vintage-engine` is added so it remains discoverable once surefire switches to `JUnitPlatformProvider`. Both are added to the existing `analyze-only` `ignoredDependencies`, since they are reached by ServiceLoader rather than by bytecode reference and `failOnWarning` is on.

### Verification
`mvn test` before and after: `Tests run: 10, Failures: 0, Errors: 0, Skipped: 0`.
`mvn -Prun-its verify` before and after: surefire 10/10, failsafe 9/9, identical. That run also shows 5 pre-existing failures in the `src/it` invoker projects (a Groovy verify-script resolution error) which are present on `master` too and are unrelated to this change.

Draft until CI confirms.

Generated-by: Claude Opus 5 (1M context)