### PR TITLE
Stop the Maven runtime pin from freezing maven-archiver

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,14 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      # ignore Maven Core updates
-      - dependency-name: "org.apache.maven:*"
+      # Pin the Maven runtime to the minimum this plugin supports.
+      # Named one by one so org.apache.maven:maven-archiver stays updatable.
+      - dependency-name: "org.apache.maven:maven-artifact"
+      - dependency-name: "org.apache.maven:maven-core"
+      - dependency-name: "org.apache.maven:maven-model"
+      - dependency-name: "org.apache.maven:maven-model-builder"
+      - dependency-name: "org.apache.maven:maven-plugin-api"
+      - dependency-name: "org.apache.maven:maven-resolver-provider"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
`org.apache.maven:*` matches that groupId exactly, and `org.apache.maven:maven-archiver` lives in it. It is a shared library carrying its own version, `3.6.3` here, not part of the `${mavenVersion}` runtime pin — so the wildcard has been holding it back since 2022. Central is at 3.6.6.

The six runtime artifacts are now named individually and stay pinned at `mavenVersion` 3.9.16, which is what the rule was written for.

Part of a sweep across the thirteen repositories carrying this wildcard; see apache/maven-archiver#394.

*This change was created with AI assistance.*
